### PR TITLE
Refactor rtc websocket DTOs

### DIFF
--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcCommandDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcCommandDto.kt
@@ -1,0 +1,22 @@
+package jm.preversion.biblewith.rtc
+
+data class RtcCommandDto(
+    val command: String,
+    val signalingCommand: String? = null,
+    val peerId: String? = null,
+    val peerIdOf: String? = null,
+    val sdp: String? = null,
+    val roomId: String? = null,
+    val roomInfo: RtcRoomDto? = null,
+    val roomList: List<RtcRoomDto>? = null,
+    val requestL: List<RtcUserDto>? = null,
+    val usersInfo: List<RtcUserDto>? = null,
+    val makerId: String? = null,
+    val sessionState: String? = null,
+    val groupId: Int? = null,
+    val title: String? = null,
+    val size: String? = null,
+    val pwd: String? = null,
+    val id: String? = null,
+    val nick: String? = null
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcFm.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcFm.kt
@@ -211,7 +211,8 @@ class RtcFm : Fragment(), HBRecorderListener {
                                     // 뒤로 가기 기능을 처리하는 로직을 여기에 추가.
                                     navigate(R.id.action_global_groupInFm)
                                 },
-                                onCreateRoom = { jo ->
+                               onCreateRoom = { jo ->
+                                    // 방 만들기 기능을 처리하는 로직을 여기에 추가.
                                     sessionManager.signalingClient.sendCommand(
                                         StandardCommand.방만들기,
                                         RtcCommandDto(

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcFm.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcFm.kt
@@ -41,8 +41,7 @@ import jm.preversion.biblewith.rtc.webrtc.peer.StreamPeerConnectionFactory
 import jm.preversion.biblewith.rtc.webrtc.sessions.LocalWebRtcSessionManager
 import jm.preversion.biblewith.rtc.webrtc.sessions.WebRtcSessionManager
 import jm.preversion.biblewith.rtc.webrtc.sessions.WebRtcSessionManagerImpl
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.rtc.RtcRoomDto
 import com.hbisoft.hbrecorder.HBRecorder
 import com.hbisoft.hbrecorder.HBRecorderListener
 import es.dmoral.toasty.Toasty
@@ -213,18 +212,16 @@ class RtcFm : Fragment(), HBRecorderListener {
                                     navigate(R.id.action_global_groupInFm)
                                 },
                                 onCreateRoom = { jo ->
-                                    // 방 만들기 기능을 처리하는 로직을 여기에 추가.
-                                    sessionManager.signalingClient.sendCommand(StandardCommand.방만들기,
-                                        JsonObject().apply {
-                                            addProperty("command", "방만들기")
-                                            addProperty("title", jo["title"].asString)
-                                            addProperty("size", jo["size"].asString)
-                                            addProperty("pwd", jo["pwd"].asString)
-                                            addProperty("groupId", groupVm.groupInfo["group_no"].asString)
-                                        }
+                                    sessionManager.signalingClient.sendCommand(
+                                        StandardCommand.방만들기,
+                                        RtcCommandDto(
+                                            command = "방만들기",
+                                            title = jo.title,
+                                            size = jo.size?.toString(),
+                                            pwd = jo.pwd,
+                                            groupId = groupVm.groupInfo["group_no"].asString.toInt()
+                                        )
                                     )
-
-
                                 }
                             )
                         }
@@ -266,10 +263,10 @@ class RtcFm : Fragment(), HBRecorderListener {
      */
     @Composable
     fun RoomList(
-        rooms: JsonArray/*List<String>*/,
-        onRoomEntrance: (JsonObject) -> Unit,
+        rooms: List<RtcRoomDto>,
+        onRoomEntrance: (RtcRoomDto) -> Unit,
         onBackPressed: () -> Unit,
-        onCreateRoom: (JsonObject) -> Unit
+        onCreateRoom: (RtcRoomDto) -> Unit
     ) {
 
         //'방접속시도', '방만들기' 등 이변수의 값에 따라 해당하는 다이얼로그를 보여주는 용도
@@ -284,9 +281,7 @@ class RtcFm : Fragment(), HBRecorderListener {
         }
 
         //rooms자체는 signalingClient의 리스너에서 JsonObject()로써 온전히 받기때문에 그 객체안의 속성이 있는지 확인해야함.
-        Log.e(tagName, "rooms: $rooms")
-        val roomL = rooms.map{ it.asJsonObject }
-        Log.e(tagName, "roomL: $roomL")
+        val roomL = rooms
 
         Column {
             TopAppBar(
@@ -309,7 +304,7 @@ class RtcFm : Fragment(), HBRecorderListener {
             LazyColumn {
                 itemsIndexed(roomL) { index, room ->
                     Text(
-                        text = "$index ${room["title"]}",
+                        text = "$index ${room.title}",
                         modifier = Modifier
                             .fillMaxWidth()
                             //방목록을 클릭하면,
@@ -320,7 +315,7 @@ class RtcFm : Fragment(), HBRecorderListener {
                     // 방접속시도에 관한 다이얼로그가 뜸.
                     if(showDialog.value == "방접속시도"){
                         CustomDialogAtRoomClick(
-                            selectedRoom = room ,
+                            selectedRoom = room,
                             onConfirmClick = onRoomEntrance,
                             onDismissClick = { hideRoomDialog() }
                         )

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcRoomDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcRoomDto.kt
@@ -1,0 +1,11 @@
+package jm.preversion.biblewith.rtc
+
+data class RtcRoomDto(
+    val roomId: String? = null,
+    val title: String? = null,
+    val size: Int? = null,
+    val pwd: String? = null,
+    val groupId: Int? = null,
+    val usersCount: Int? = null,
+    val makerId: String? = null
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcUserDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcUserDto.kt
@@ -1,0 +1,6 @@
+package jm.preversion.biblewith.rtc
+
+data class RtcUserDto(
+    val userId: String,
+    val nick: String? = null
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcVm.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/RtcVm.kt
@@ -7,8 +7,9 @@ import jm.preversion.biblewith.group.GroupVm
 import jm.preversion.biblewith.rtc.webrtc.sessions.ChatData
 import jm.preversion.biblewith.rtc.webrtc.sessions.WebRtcSessionManagerImpl
 import jm.preversion.biblewith.util.FileHelperV2
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.rtc.RtcRoomDto
+import jm.preversion.biblewith.rtc.RtcUserDto
+import jm.preversion.biblewith.rtc.RtcCommandDto
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
@@ -20,23 +21,23 @@ class RtcVm : ViewModel() {
     val fileHelper = FileHelperV2()
 
 
-    val 접속한방정보읽기: JsonObject
+    val 접속한방정보읽기: RtcRoomDto?
         get() = sessionManager.signalingClient._접속한방정보.value
 
-    val 접속한방정보: StateFlow<JsonObject>
+    val 접속한방정보: StateFlow<RtcRoomDto?>
         get() = sessionManager.signalingClient._접속한방정보
 
-    val 방참가시접속인원목록: StateFlow<JsonArray>
+    val 방참가시접속인원목록: StateFlow<List<RtcUserDto>>
         get() = sessionManager.signalingClient._방참가시접속인원목록
 
-    val 전달받은명령상태값: StateFlow<JsonObject>
+    val 전달받은명령상태값: StateFlow<RtcCommandDto?>
         get() = sessionManager.signalingClient._전달받은명령상태값
 
-    val 방장에게접속요청자목록: StateFlow<JsonArray>
+    val 방장에게접속요청자목록: StateFlow<List<RtcUserDto>>
         get() = sessionManager.signalingClient._방장에게접속요청자목록
 
     val 방장에게접속요청자목록size :Int
-        get() = sessionManager.signalingClient._방장에게접속요청자목록.value.size()
+        get() = sessionManager.signalingClient._방장에게접속요청자목록.value.size
 
 
 

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/components/CustomDialog.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/components/CustomDialog.kt
@@ -9,11 +9,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
 import jm.preversion.biblewith.rtc.RtcFm
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.rtc.RtcRoomDto
 
 @Composable
 fun CustomDialog(
-    onConfirmClick: (JsonObject) -> Unit,
+    onConfirmClick: (RtcRoomDto) -> Unit,
     onDismissClick: () -> Unit,
 ) {
 //    var title = title
@@ -65,12 +65,11 @@ fun CustomDialog(
             TextButton(
                 onClick = {
                     onConfirmClick(
-                        //상위 전달 인자로 json object를 전달함.
-                        JsonObject().apply { 
-                            addProperty("title", title)
-                            addProperty("size", size)
-                            addProperty("pwd", pwd)
-                        }
+                        RtcRoomDto(
+                            title = title,
+                            size = size.toIntOrNull(),
+                            pwd = pwd
+                        )
                     )
                     onDismissClick()
                 }

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/components/CustomDialogAtRoomClick.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/components/CustomDialogAtRoomClick.kt
@@ -14,12 +14,12 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import jm.preversion.biblewith.rtc.RtcVm
 import jm.preversion.biblewith.rtc.webrtc.StandardCommand
 import jm.preversion.biblewith.rtc.webrtc.sessions.LocalWebRtcSessionManager
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.rtc.RtcRoomDto
 
 @Composable
 fun CustomDialogAtRoomClick(
-    selectedRoom: JsonObject,
-    onConfirmClick: (JsonObject) -> Unit,
+    selectedRoom: RtcRoomDto,
+    onConfirmClick: (RtcRoomDto) -> Unit,
     onDismissClick: () -> Unit,
 ) {
 //    val groupVm = LocalViewModel.current as GroupVm //모임 아이디를 서버통신에 전달하기 위한 용도.
@@ -62,7 +62,7 @@ fun CustomDialogAtRoomClick(
 
     AlertDialog(
         onDismissRequest = { onDismissClick() },
-        title = { Text(text = "참가할 방: ${selectedRoom["title"].asString}") },
+        title = { Text(text = "참가할 방: ${selectedRoom.title}") },
         text = {
             //보냄인경우 LaunchedEffect에서 관찰하고있는 'rtcVm.방접속시도시접속인원목록'의 상태값에 따라 추후 '완료'로 바뀜.
             when(state) {
@@ -86,7 +86,7 @@ fun CustomDialogAtRoomClick(
                     Column {
                         //                buildAnnotatedString {  }
                         Text(
-                            text = "방인원수: ${selectedRoom["usersCount"]} / $size",
+                            text = "방인원수: ${selectedRoom.usersCount} / $size",
                             modifier = Modifier.fillMaxWidth()
                         )
                         Text(
@@ -100,7 +100,7 @@ fun CustomDialogAtRoomClick(
                     Column {
                         //                buildAnnotatedString {  }
                         Text(
-                            text = "방인원수: ${selectedRoom["usersCount"]} / $size",
+                            text = "방인원수: ${selectedRoom.usersCount} / $size",
                             modifier = Modifier.fillMaxWidth()
                         )
                         Text(
@@ -141,10 +141,13 @@ fun CustomDialogAtRoomClick(
                         //  방장이 위에서 만들었던 뷰에서 확인하고 수락후, 다시 서버로 '수락함'이라는 메소드를 받으면 그 수락된 id에 해당하는
                         //  user에게 현재'방접속시도'에 해당하는 로직으로 여기 신호가 와서 '완료'로 바뀌게끔 해줘야함.
 
-                        sessionManager.signalingClient.sendCommand(StandardCommand.방접속요청, JsonObject().apply {
-                            addProperty("command", StandardCommand.방접속요청.name)
-                            addProperty("roomId", selectedRoom["roomId"].asString)
-                        })
+                        sessionManager.signalingClient.sendCommand(
+                            StandardCommand.방접속요청,
+                            RtcCommandDto(
+                                command = StandardCommand.방접속요청.name,
+                                roomId = selectedRoom.roomId
+                            )
+                        )
 
 
 

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/components/JoinRequestDialog.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/components/JoinRequestDialog.kt
@@ -33,6 +33,7 @@ import jm.preversion.biblewith.R
 import jm.preversion.biblewith.rtc.RtcVm
 import jm.preversion.biblewith.rtc.ui.theme.CustomModifier
 import jm.preversion.biblewith.rtc.webrtc.StandardCommand
+import jm.preversion.biblewith.rtc.RtcUserDto
 
 
 val padding = 16.dp
@@ -41,13 +42,7 @@ val padding = 16.dp
 fun JoinRequestDialog(onDismiss: () -> Unit) {
     val contextForToast = LocalContext.current.applicationContext
     val rtcVm = viewModel<RtcVm>()
-    val _requestList by rtcVm.방장에게접속요청자목록.collectAsState()
-    //서버로부터 받아온 요청자목록을 List로 변환하여, view에 사용.
-    val requestList = _requestList.run {
-        map {
-            it.asJsonObject
-        }
-    }
+    val requestList by rtcVm.방장에게접속요청자목록.collectAsState()
 
 
     Dialog(
@@ -114,7 +109,7 @@ fun JoinRequestDialog(onDismiss: () -> Unit) {
 
                             Text(
                                 modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 16.dp),
-                                text = item["nick"].asString,
+                                text = item.nick ?: "",
                                 textAlign = TextAlign.Center,
                                 style = TextStyle(
                                     fontFamily = FontFamily(Font(R.font.binggraetaombold, FontWeight.Bold)),
@@ -135,11 +130,10 @@ fun JoinRequestDialog(onDismiss: () -> Unit) {
                                         // todo 여기서 수락시 서버로 해당하는 접속자에게 방에 참가하라는 명령을 보내줌.
                                         rtcVm.sessionManager.signalingClient.sendCommand(
                                             StandardCommand.방참가수락,
-                                            item.run {
-                                                deepCopy().also {
-                                                    it.addProperty("command", StandardCommand.방참가수락.name)
-                                                }
-                                            }
+                                            RtcCommandDto(
+                                                command = StandardCommand.방참가수락.name,
+                                                peerId = item.userId
+                                            )
                                         )
 
 

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/screens/video/VideoCallControlAction.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/screens/video/VideoCallControlAction.kt
@@ -75,7 +75,7 @@ fun buildDefaultCallControlActions(
 
     val actions = mutableListOf<VideoCallControlAction>().apply {
         // 방장유무 조건에 따라 달라지는 요소 추가
-        if (rtcVm.접속한방정보읽기["makerId"].asString == MyApp.userInfo.user_email) {
+        if (rtcVm.접속한방정보읽기?.makerId == MyApp.userInfo.user_email) {
             add(VideoCallControlAction(
                 icon = requestListIcon,
                 iconTint = if (callMediaState.isRequestList) Color.Green else Color.LightGray,

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/screens/video/VideoCallScreen.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/ui/screens/video/VideoCallScreen.kt
@@ -408,7 +408,7 @@ fun VideoCallScreen() {
 
 
         //방장일때 참가요청자가 있는지 확인해야함.
-        if ((rtcVm.접속한방정보읽기["makerId"].asString == MyApp.userInfo.user_email) && callMediaState.isRequestList
+        if ((rtcVm.접속한방정보읽기?.makerId == MyApp.userInfo.user_email) && callMediaState.isRequestList
             && 다이얼로그보여주기.value == "요청자목록"
         ){
             JoinRequestDialog { 다이얼로그닫기() }

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/webrtc/SignalingClient.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/webrtc/SignalingClient.kt
@@ -149,8 +149,8 @@ class SignalingClient(val groupVm: GroupVm) {
             command = "signalingCommand",
             signalingCommand = signalingCommand.name,
             peerId = peerId,
-            peerIdOf = peerIdOf,
-            sdp = message
+            peerIdOf = peerIdOf, // sendAnswer()에서 사용됨. 다른데서는 사용x
+            sdp = message //OFFER, ANSWER의 경우 SDP. ICE의 경우 iceCandidate.sdpMid, sdpMLineIndex, sdp 3가지 정보.
         )
         ws.send(gson.toJson(jOut))
 //        ws.send("$signalingCommand $message")
@@ -168,6 +168,7 @@ class SignalingClient(val groupVm: GroupVm) {
 
             try {
                 // websocket 메시지를 DTO 로 변환
+                //websocket으로 들어오는 메시지를 json object로 해석.
                 val jin = gson.fromJson(text, RtcCommandDto::class.java)
                 val command = jin.command
 
@@ -215,17 +216,23 @@ class SignalingClient(val groupVm: GroupVm) {
                         Log.e(tagName, "방목록전달 jin: $jin")
                         signalingScope.launch {
                             val roomList = jin.roomList ?: emptyList()
+//                        updateRoomList(roomList)
                             _roomList.emit(roomList)
                         }
                     }
                     StandardCommand.방만들기.name -> {
                         Log.e(tagName, "방만들기 jin: $jin")
+                        //map을 tojson으로 변환한건데 이게 JsonObject로 변환된건지 잘모르겠네.
 
                         signalingScope.launch {
+                            //서버로부터 받아온 방목록을 업데이트 해주고,
                             val roomList = jin.roomList ?: emptyList()
                             Log.e(tagName, "방만들기 roomList: $roomList")
+//                            updateRoomList(roomList)
                             _roomList.emit(roomList)
 
+                            // todo 방만들기시에 방장이 방에 바로 접속할 수 있도록 하는 코드를 짜야함.
+                            // 서버로부터 방을 만든 아이디를 전달받아 비교하여, 방장본인이 만든 방이면 방장을 바로 비디오화면으로 전환함.
                             if (jin.makerId == MyApp.userInfo.user_email) {
                                 setCurrentScreen(RtcFm.ScreenState.VIDEO_CALL_SCREEN)
                                 jin.roomInfo?.let { _접속한방정보.emit(it) }
@@ -234,13 +241,18 @@ class SignalingClient(val groupVm: GroupVm) {
                     }
                     StandardCommand.방접속요청.name -> {
                         Log.e(tagName, "방접속요청 jin: $jin")
+//                        val roomId = jin["roomId"].asString
+//                        _전달받은명령상태값.value = jin
                         signalingScope.launch {
+                            //roomId, groupId에 해당하는 방장에게 userId에 대한 수락요청을 보내야함.
+//                            _전달받은명령상태값.emit(jin)
                             _방장에게접속요청자목록.emit(jin.requestL ?: emptyList())
                         }
                     }
                     StandardCommand.방참가수락.name -> {
                         Log.e(tagName, "방참가수락 jin: $jin")
                         val usersInfo = jin.usersInfo ?: emptyList()
+//                        val usersInfo = jin["usersInfo"].asJsonArray
                         signalingScope.launch {
                             _방참가시접속인원목록.emit(usersInfo)
 
@@ -256,6 +268,9 @@ class SignalingClient(val groupVm: GroupVm) {
                     }
                     StandardCommand.방접속.name -> {
                         Log.e(tagName, "방접속 jin: $jin")
+//                        val userIds = jin["userIds"].asJsonArray
+                        // 소켓으로부터 이 응답을 받으면, 이 클라이언트의 화면을 VIDEO_CALL_SCREEN 으로 전환.
+                        // 거기서 _방참가시접속인원목록.value 의 값을 이용해 원격 비디오 렌더링뷰를 셋팅해야함.
                         _접속한방정보.value = jin.roomInfo
                         setCurrentScreen(RtcFm.ScreenState.VIDEO_CALL_SCREEN)
                     }
@@ -269,8 +284,13 @@ class SignalingClient(val groupVm: GroupVm) {
                     }
                     StandardCommand.방종료.name -> {
                         Log.e(tagName, "방종료 jin: $jin")
+//                        val roomId = jin["roomId"].asString
+                        //방장이 나가면 방종료하는 부분인데, 현재 방목록에서 방이 제거되긴 함.
+                        // 다만, 연결된 피어들은 그대로 통화를 진행중임. 이부분은 어떻게 할지 고민해봐야할듯. 그대로둘지 끊을지.
                         val roomId = jin.roomId
                         val verifiedArray = _roomList.value.filterNot { it.roomId == roomId }
+                        // todo  emit 안하고도 상태값의 변화가 감지될려나? 방이 리스트에서 제대로 종료안되면 확인해봐야함.
+//                        _roomList.emit(verifiedArray)
                         _roomList.value = verifiedArray
                     }
 
@@ -318,6 +338,7 @@ class SignalingClient(val groupVm: GroupVm) {
         val mType =  message.signalingCommand
         val state = message.sessionState
         Log.w(tagName, "handleStateMessage: $mType, $state")
+//        val state = getSeparatedMessage(message) //message에 공백이 포함되어 있을 수 있기 때문에 텍스트 전처리함.
         state?.let {
             _sessionStateFlow.value = WebRTCSessionState.valueOf(it)
         }

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/webrtc/SignalingClient.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/webrtc/SignalingClient.kt
@@ -1,11 +1,14 @@
 package jm.preversion.biblewith.rtc.webrtc
+
 import android.util.Log
 import jm.preversion.biblewith.BuildConfig
 import jm.preversion.biblewith.MyApp
 import jm.preversion.biblewith.group.GroupVm
+import jm.preversion.biblewith.rtc.RtcCommandDto
 import jm.preversion.biblewith.rtc.RtcFm
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.rtc.RtcRoomDto
+import jm.preversion.biblewith.rtc.RtcUserDto
+import com.google.gson.Gson
 import com.google.gson.JsonParser
 
 import io.getstream.log.taggedLogger
@@ -20,10 +23,21 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import okhttp3.*
 
+/**
+ * WebSocket 메시지에서 사용되는 주요 JSON 필드
+ *  - command, signalingCommand
+ *  - peerId, peerIdOf, sdp
+ *  - id, nick, groupId
+ *  - roomList, roomInfo, makerId, roomId
+ *  - requestL, usersInfo
+ *  - title, size, pwd
+ *  - sessionState
+ */
 class SignalingClient(val groupVm: GroupVm) {
 
     val tagName = "[${this.javaClass.simpleName}]"
     private val logger by taggedLogger("Call:SignalingClient")
+    private val gson = Gson()
 
     // SupervisorJob() 은 코루틴을 계층적으로 사용하기 위한 기능. 이것을 더해서 범위를 설정하면 곧 최상위 작업이 되고, 하위의 코루틴 작업의 취소
     // 는 이 작업의 취소에는 영향을 미치지 않음. 다만, 하위 코루틴의 취소에 대한 예외처리는 CoroutineExceptionHandler 통해 가능함.
@@ -48,16 +62,16 @@ class SignalingClient(val groupVm: GroupVm) {
     // 시그널링 서버로부터 온 message text에 따른 SignalingCommand의 값을 변화시켜(flow발생)
     // 이 Flow를 collect(구독)하고 있는 구독자가 collect를 실행하게함.
     // 웹소켓의 리스너의 onMessage에 따라 해당하는 상태메시지의 handleSignalingCommand()가 실행되고 이 값이 변경됨.
-    private val _signalingCommandFlow = MutableSharedFlow<Pair<SignalingCommand, JsonObject>>()
-    val signalingCommandFlow: SharedFlow<Pair<SignalingCommand, JsonObject>> = _signalingCommandFlow
+    private val _signalingCommandFlow = MutableSharedFlow<Pair<SignalingCommand, RtcCommandDto>>()
+    val signalingCommandFlow: SharedFlow<Pair<SignalingCommand, RtcCommandDto>> = _signalingCommandFlow
 
 
 
     /**
      * 방목록 관련 상태 변수들.
      */
-    private val _roomList = MutableStateFlow(JsonArray())
-    val roomList: StateFlow<JsonArray> = _roomList
+    private val _roomList = MutableStateFlow(emptyList<RtcRoomDto>())
+    val roomList: StateFlow<List<RtcRoomDto>> = _roomList
 
     private val _currentScreen = MutableStateFlow(RtcFm.ScreenState.ROOM_LIST)
     val currentScreen: StateFlow<RtcFm.ScreenState> = _currentScreen/*.asStateFlow()*/
@@ -65,20 +79,20 @@ class SignalingClient(val groupVm: GroupVm) {
     /**
      * 현재 접속한 방에 대한 정보 - 방만들기 , 방접속시 업데이트됨
      */
-    var _접속한방정보 = MutableStateFlow(JsonObject())
+    var _접속한방정보 = MutableStateFlow<RtcRoomDto?>(null)
 
     /**
      * RtcVm에서 관찰중임 -> CustomDialogAtRoomClick 다이얼로그에서 받아씀.
      */
-    var _방참가시접속인원목록 = MutableStateFlow(JsonArray())
-    val 방참가시접속인원목록: StateFlow<JsonArray> = _방참가시접속인원목록
+    var _방참가시접속인원목록 = MutableStateFlow(emptyList<RtcUserDto>())
+    val 방참가시접속인원목록: StateFlow<List<RtcUserDto>> = _방참가시접속인원목록
 
-    var _전달받은명령상태값 = MutableStateFlow(JsonObject())
+    var _전달받은명령상태값 = MutableStateFlow<RtcCommandDto?>(null)
 
     /**
      * 방에 참가요청자 명단 - 방장용
      */
-    var _방장에게접속요청자목록 = MutableStateFlow(JsonArray())
+    var _방장에게접속요청자목록 = MutableStateFlow(emptyList<RtcUserDto>())
 
 
 
@@ -96,13 +110,14 @@ class SignalingClient(val groupVm: GroupVm) {
     init {
         //이 객체가 처음 생성될때(앱이 페이지들올때)마다 실행하여 시그널링 서버에 클라이언트 정보 중복확인하고 등록해야함.
         // (clients map에 등록)
-        val jOut = JsonObject()
-        jOut.addProperty("command", "ws_init")
-        jOut.addProperty("id", MyApp.userInfo.user_email)
-        jOut.addProperty("nick", MyApp.userInfo.user_nick)
-        jOut.addProperty("groupId", groupVm.groupInfo.get("group_no").asInt)
+        val jOut = RtcCommandDto(
+            command = "ws_init",
+            id = MyApp.userInfo.user_email,
+            nick = MyApp.userInfo.user_nick,
+            groupId = groupVm.groupInfo.get("group_no").asInt
+        )
         logger.w { "[sendCommand Init] $jOut" }
-        ws.send("$jOut")
+        ws.send(gson.toJson(jOut))
 
         //TODO 이후에 할일: 방먼저 만들고 만든 방들을 초기에 RTCFM PAGE로 접속시 리사이클러뷰로 로드해올수 있도록 목록을 소켓으로부터 받아야함.
 
@@ -113,13 +128,13 @@ class SignalingClient(val groupVm: GroupVm) {
     /**
      * 시그널링 서버로 명령어와 그에 필요한 정보를 문자열로 보냄.
      */
-    fun sendCommand(standardCommand: StandardCommand, jOut: JsonObject) {
+    fun sendCommand(standardCommand: StandardCommand, jOut: RtcCommandDto) {
         logger.w { "sendCommand() jOut: $standardCommand, $jOut" }
 //        val jOut = JsonObject()
 //        jOut.addProperty("command", "signalingCommand")
 //        jOut.addProperty("signalingCommand", "$standardCommand")
 
-        ws.send(jOut.toString())
+        ws.send(gson.toJson(jOut))
     }
 
 
@@ -130,14 +145,14 @@ class SignalingClient(val groupVm: GroupVm) {
         if(signalingCommand != SignalingCommand.ICE){
             logger.d { "sendCommand() SignalingCommand: $signalingCommand" }
         }
-        val jOut = JsonObject()
-        jOut.addProperty("command", "signalingCommand")
-        jOut.addProperty("signalingCommand", "$signalingCommand")
-        //OFFER, ANSWER의 경우 SDP. ICE의 경우 iceCandidate.sdpMid, sdpMLineIndex, sdp 3가지 정보.
-        jOut.addProperty("peerId", peerId)
-        jOut.addProperty("peerIdOf", peerIdOf) // sendAnswer()에서 사용됨. 다른데서는 사용x
-        jOut.addProperty("sdp", message)
-        ws.send(jOut.toString())
+        val jOut = RtcCommandDto(
+            command = "signalingCommand",
+            signalingCommand = signalingCommand.name,
+            peerId = peerId,
+            peerIdOf = peerIdOf,
+            sdp = message
+        )
+        ws.send(gson.toJson(jOut))
 //        ws.send("$signalingCommand $message")
     }
 
@@ -152,13 +167,13 @@ class SignalingClient(val groupVm: GroupVm) {
 //            Log.e(tagName, "onMessage(): $text")
 
             try {
-                //websocket으로 들어오는 메시지를 json object로 해석.
-                val jin = JsonParser.parseString(text).asJsonObject
-                val command = jin["command"].asString
+                // websocket 메시지를 DTO 로 변환
+                val jin = gson.fromJson(text, RtcCommandDto::class.java)
+                val command = jin.command
 
                 when(command){
                     "signalingCommand" -> {
-                        val signalingCommand: String = jin.get("signalingCommand").asString
+                        val signalingCommand: String = jin.signalingCommand ?: return
                         // 각 응답의 내용에 따른 메소드를 호출함.
                         when {
                             //text의 앞글자가 STATE 일때 실행.
@@ -199,59 +214,49 @@ class SignalingClient(val groupVm: GroupVm) {
                     StandardCommand.방목록전달.name -> {
                         Log.e(tagName, "방목록전달 jin: $jin")
                         signalingScope.launch {
-                            val roomList = jin["roomList"].asJsonArray
-    //                        updateRoomList(roomList)
+                            val roomList = jin.roomList ?: emptyList()
                             _roomList.emit(roomList)
                         }
                     }
                     StandardCommand.방만들기.name -> {
-                        //map을 tojson으로 변환한건데 이게 JsonObject로 변환된건지 잘모르겠네.
                         Log.e(tagName, "방만들기 jin: $jin")
 
                         signalingScope.launch {
-                            //서버로부터 받아온 방목록을 업데이트 해주고,
-                            val roomList = jin["roomList"].asJsonArray
+                            val roomList = jin.roomList ?: emptyList()
                             Log.e(tagName, "방만들기 roomList: $roomList")
-//                            updateRoomList(roomList)
                             _roomList.emit(roomList)
 
-                            // todo 방만들기시에 방장이 방에 바로 접속할 수 있도록 하는 코드를 짜야함.
-                            // 서버로부터 방을 만든 아이디를 전달받아 비교하여, 방장본인이 만든 방이면 방장을 바로 비디오화면으로 전환함.
-                            if(jin["makerId"].asString == MyApp.userInfo.user_email){
+                            if (jin.makerId == MyApp.userInfo.user_email) {
                                 setCurrentScreen(RtcFm.ScreenState.VIDEO_CALL_SCREEN)
-                                _접속한방정보.emit(jin["roomInfo"].asJsonObject)
+                                jin.roomInfo?.let { _접속한방정보.emit(it) }
                             }
                         }
                     }
                     StandardCommand.방접속요청.name -> {
                         Log.e(tagName, "방접속요청 jin: $jin")
-//                        val roomId = jin["roomId"].asString
-//                        _전달받은명령상태값.value = jin
                         signalingScope.launch {
-                            //roomId, groupId에 해당하는 방장에게 userId에 대한 수락요청을 보내야함.
-//                            _전달받은명령상태값.emit(jin)
-                            _방장에게접속요청자목록.emit(jin["requestL"].asJsonArray)
+                            _방장에게접속요청자목록.emit(jin.requestL ?: emptyList())
                         }
                     }
                     StandardCommand.방참가수락.name -> {
                         Log.e(tagName, "방참가수락 jin: $jin")
-                        val usersInfo = jin["usersInfo"].asJsonArray
+                        val usersInfo = jin.usersInfo ?: emptyList()
                         signalingScope.launch {
                             _방참가시접속인원목록.emit(usersInfo)
 
                             //수락받으면 인원수 초과등 검사를 위해 다시 서버로 보내줌.
-                            sendCommand(StandardCommand.방접속, JsonObject().apply {
-                                addProperty("command", "방접속")
-                                addProperty("makerId", jin["makerId"].asString)
-                            })
+                            sendCommand(
+                                StandardCommand.방접속,
+                                RtcCommandDto(
+                                    command = "방접속",
+                                    makerId = jin.makerId
+                                )
+                            )
                         }
                     }
                     StandardCommand.방접속.name -> {
                         Log.e(tagName, "방접속 jin: $jin")
-//                        val userIds = jin["userIds"].asJsonArray
-                        // 소켓으로부터 이 응답을 받으면, 이 클라이언트의 화면을 VIDEO_CALL_SCREEN 으로 전환.
-                        // 거기서 _방참가시접속인원목록.value 의 값을 이용해 원격 비디오 렌더링뷰를 셋팅해야함.
-                        _접속한방정보.value = jin["roomInfo"].asJsonObject
+                        _접속한방정보.value = jin.roomInfo
                         setCurrentScreen(RtcFm.ScreenState.VIDEO_CALL_SCREEN)
                     }
                     "피어연결종료신호" -> {
@@ -264,16 +269,9 @@ class SignalingClient(val groupVm: GroupVm) {
                     }
                     StandardCommand.방종료.name -> {
                         Log.e(tagName, "방종료 jin: $jin")
-                        val roomId = jin["roomId"].asString
-                        //방장이 나가면 방종료하는 부분인데, 현재 방목록에서 방이 제거되긴 함.
-                        // 다만, 연결된 피어들은 그대로 통화를 진행중임. 이부분은 어떻게 할지 고민해봐야할듯. 그대로둘지 끊을지.
-                        val verifiedArray = _roomList.value.run {
-                            remove(find {
-                                it.asJsonObject["roomId"].asString == roomId
-                            })
-                        }
-                        // todo  emit 안하고도 상태값의 변화가 감지될려나? 방이 리스트에서 제대로 종료안되면 확인해봐야함.
-//                        _roomList.emit(verifiedArray)
+                        val roomId = jin.roomId
+                        val verifiedArray = _roomList.value.filterNot { it.roomId == roomId }
+                        _roomList.value = verifiedArray
                     }
 
                 }
@@ -316,19 +314,20 @@ class SignalingClient(val groupVm: GroupVm) {
      * 서버로부터 'STATE Ready' 값을 받으면 _sessionStateFlow의 상태값을 업데이트하고
      * 그 변화를 감지한 Ui 컴포지션은 조건에 따라 다음 작업을 진행한다.
      */
-    private fun handleStateMessage(message: JsonObject) {
-        val mType =  message["signalingCommand"].asString
-        val state = message["sessionState"].asString
+    private fun handleStateMessage(message: RtcCommandDto) {
+        val mType =  message.signalingCommand
+        val state = message.sessionState
         Log.w(tagName, "handleStateMessage: $mType, $state")
-//        val state = getSeparatedMessage(message) //message에 공백이 포함되어 있을 수 있기 때문에 텍스트 전처리함.
-        _sessionStateFlow.value = WebRTCSessionState.valueOf(state)
+        state?.let {
+            _sessionStateFlow.value = WebRTCSessionState.valueOf(it)
+        }
     }
 
     /**
      * 서버로부터 받은 명령타입의 상태값이 'STATE'이외(OFFER ANSWER ICE) 값이라면 실행하는 메소드.
      * 세션 상태 Flow 값을 업데이트함.
      */
-    private fun handleSignalingCommand(command: SignalingCommand, message: JsonObject) {
+    private fun handleSignalingCommand(command: SignalingCommand, message: RtcCommandDto) {
 //        val mType =  message["signalingCommand"].asString
 //        val value = getSeparatedMessage(text)
 //        val sdp = message["sdp"].asString

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/webrtc/sessions/WebRtcSessionManagerImpl.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/rtc/webrtc/sessions/WebRtcSessionManagerImpl.kt
@@ -357,16 +357,11 @@ class WebRtcSessionManagerImpl(
             // 해당 시그널 상황에서 클라이언트가 해야할 작업들인 handle**() 메소드가 실행된다.
             //handleAnswer(), handleIce()내에서 peerConnection 객체를 사용함.
             signalingClient.signalingCommandFlow.collect { pair ->
-                //상태값의 키페어를 가져와 사용. second에는 보통 SPD 문자열이 담김.
                 when (pair.first) {
-                    //signalingCommandFlow의 state 값이 변할때마다 실행됨.
-                    // OFFER가 두개면 두번 실행됨. 예)peer B와 C가 이곳 A에게 OFFER주는 상황 등.
-                    // 이때, 이곳 A는 B와 C의 peerId를 확인하여 해당 아이디로 이미 생성된 peerConnection 객체가
-                    // 있는지 map에서 먼저 확인해야함.
-                    SignalingCommand.OFFER -> handleOffer(pair.second["peerId"].asString, pair.second["sdp"].asString)
-                    SignalingCommand.ANSWER -> handleAnswer(pair.second["peerId"].asString, pair.second["sdp"].asString)
-                    SignalingCommand.ICE -> handleIce(pair.second["peerIdOf"].asString, pair.second["sdp"].asString)
-                    SignalingCommand.CLOSE -> handleClose(pair.second["peerId"]?.asString?:"none")
+                    SignalingCommand.OFFER -> handleOffer(pair.second.peerId ?: "", pair.second.sdp ?: "")
+                    SignalingCommand.ANSWER -> handleAnswer(pair.second.peerId ?: "", pair.second.sdp ?: "")
+                    SignalingCommand.ICE -> handleIce(pair.second.peerIdOf ?: "", pair.second.sdp ?: "")
+                    SignalingCommand.CLOSE -> handleClose(pair.second.peerId ?: "none")
                     else -> Unit
                 }
             }
@@ -401,8 +396,8 @@ class WebRtcSessionManagerImpl(
             // todo 현재 접속할 방의 정보(접속한 peer들의 id)를 받아와 반복문으로 각각의 peer에 OFFER 요청을 해야함.
             //  주의: 최신 정보를 담고 있지는 않음. '참가' 버튼을 누르기까지 대기시간이 존재해서, 실제 방참가시 시간차가 있음.
             signalingClient.방참가시접속인원목록.value.forEach { userInfo ->
-                val peerId = userInfo.asJsonObject["userId"].asString
-                if(peerId != MyApp.userInfo.user_email){ // 방접속원의 아이디가 본인이라면 오퍼 안해야함.
+                val peerId = userInfo.userId
+                if (peerId != MyApp.userInfo.user_email) {
                     sendOffer(peerId)
                 }
             }


### PR DESCRIPTION
## Summary
- document websocket JSON fields
- introduce `RtcRoomDto`, `RtcUserDto`, and `RtcCommandDto`
- replace raw JsonObject usage with DTOs in SignalingClient
- adjust RtcVm, RtcFm, and related UI components to handle new DTOs
- update WebRtcSessionManagerImpl accordingly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431ea66640832b9296e435e8ee7951