### PR TITLE
Add Kotlin LoginResponseDto

### DIFF
--- a/androidclient/app/src/main/java/jm/preversion/biblewith/login/dto/LoginResponseDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/login/dto/LoginResponseDto.kt
@@ -1,0 +1,3 @@
+package jm.preversion.biblewith.login.dto
+
+data class LoginResponseDto(var result: Boolean, var msg: String)


### PR DESCRIPTION
## Summary
- add `LoginResponseDto.kt` data class
- confirm Gradle build fails in container environment (missing JDK compatibility)

## Testing
- `./gradlew assemble` *(fails: unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68445e2893f4832b80cbc3a8d7289268