### PR TITLE
Use DTO for login API responses

### DIFF
--- a/androidclient/app/src/main/java/jm/preversion/biblewith/login/FindPwFm.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/login/FindPwFm.java
@@ -19,7 +19,7 @@ import androidx.navigation.fragment.NavHostFragment;
 
 import jm.preversion.biblewith.R;
 import jm.preversion.biblewith.databinding.LoginFindPwFmBinding;
-import com.google.gson.JsonObject;
+import jm.preversion.biblewith.login.dto.LoginResponseDto;
 
 import java.util.HashMap;
 
@@ -63,15 +63,15 @@ public class FindPwFm extends Fragment {
             infoMap.put("user_email", binding.findpwEmailInput.getText().toString());
             infoMap.put("user_name",binding.findpwNameInput.getText().toString());
 
-            loginVm.비번찾기인증번호발송클릭(infoMap).enqueue(new Callback<JsonObject>() {
+            loginVm.비번찾기인증번호발송클릭(infoMap).enqueue(new Callback<LoginResponseDto>() {
                 @Override
-                public void onResponse(Call<JsonObject> call, Response<JsonObject> response) {
+                public void onResponse(Call<LoginResponseDto> call, Response<LoginResponseDto> response) {
                     if (response.isSuccessful()) {
-                        JsonObject res = response.body();
+                        LoginResponseDto res = response.body();
                         Log.e("[findpwFm]", "비번찾기인증번호발송클릭 onResponse: 통신성공, 결과는: "+ res.toString() );
 
                         //입력한 이름과 이메일이 존재하지않으면 toast 로 '존재하지 않는 회원입니다' 이라고 띄운다.
-                        if (res.get("result").getAsBoolean()){
+                        if (res.isResult()){
                             Toast.makeText(getActivity(), "인증 메일을 보냈습니다.", Toast.LENGTH_SHORT).show();
                             // todo: 인증메일 보내기 smtp - 서버에서 메일 보내기
                             binding.findpwEmailVerifyGroup1.setVisibility(View.VISIBLE); //그리고 인증번호 입력 그룹 보여줌.
@@ -84,13 +84,13 @@ public class FindPwFm extends Fragment {
 
 
                         } else {
-                            Toast.makeText(getActivity(), res.get("msg").getAsString(), Toast.LENGTH_SHORT).show();
+                            Toast.makeText(getActivity(), res.getMsg(), Toast.LENGTH_SHORT).show();
                         }
 
                     }
                 }
                 @Override
-                public void onFailure(Call<JsonObject> call, Throwable t) {
+                public void onFailure(Call<LoginResponseDto> call, Throwable t) {
                     Log.e("[findpwFm]", "비번찾기인증번호발송클릭 onFailure: "+ t.getMessage() );
                 }
             });
@@ -103,15 +103,15 @@ public class FindPwFm extends Fragment {
             infoMap.put("name",binding.findpwNameInput.getText().toString());
             infoMap.put("email", binding.findpwEmailInput.getText().toString());
 
-            loginVm.인증번호확인클릭(infoMap).enqueue(new Callback<JsonObject>() {
+            loginVm.인증번호확인클릭(infoMap).enqueue(new Callback<LoginResponseDto>() {
                 @Override
-                public void onResponse(Call<JsonObject> call, Response<JsonObject> response) {
+                public void onResponse(Call<LoginResponseDto> call, Response<LoginResponseDto> response) {
                     if (response.isSuccessful()) {
-                        JsonObject res = response.body();
+                        LoginResponseDto res = response.body();
                         Log.e("[findpwFm]", "인증번호확인클릭 onResponse: 통신성공, 결과는: "+ res.toString() );
 
-                        if (res.get("result").getAsBoolean()){
-                            Toast.makeText(getActivity(), res.get("msg").getAsString(), Toast.LENGTH_SHORT).show();
+                        if (res.isResult()){
+                            Toast.makeText(getActivity(), res.getMsg(), Toast.LENGTH_SHORT).show();
                             binding.findpwNameEmailInputGroup3.setVisibility(View.GONE); //이메일, 이름 입력 그룹 해제
                             binding.findpwEmailVerifyGroup1.setVisibility(View.GONE);   //인증번호 입력 그룹 해제
                             binding.findpwNewpwGroup2.setVisibility(View.VISIBLE);      //새 비밀번호 입력 그룹 활성
@@ -119,13 +119,13 @@ public class FindPwFm extends Fragment {
                             binding.findpwTv.setText("새 비밀번호 설정");
 
                         } else {
-                            Toast.makeText(getActivity(), res.get("msg").getAsString(), Toast.LENGTH_SHORT).show();
+                            Toast.makeText(getActivity(), res.getMsg(), Toast.LENGTH_SHORT).show();
                         }
                     }
                 }
 
                 @Override
-                public void onFailure(Call<JsonObject> call, Throwable t) {
+                public void onFailure(Call<LoginResponseDto> call, Throwable t) {
                     Log.e("[findpwFm]", "인증번호확인클릭 onFailure: "+ t.getMessage() );
                 }
             });
@@ -140,25 +140,25 @@ public class FindPwFm extends Fragment {
             info.put("user_pwd", binding.findpwPwInput.getText().toString());
             info.put("user_email", binding.findpwEmailInput.getText().toString());
 
-            loginVm.새비밀번호변경완료클릭(info).enqueue(new Callback<JsonObject>() {
+            loginVm.새비밀번호변경완료클릭(info).enqueue(new Callback<LoginResponseDto>() {
                 @Override
-                public void onResponse(Call<JsonObject> call, Response<JsonObject> response) {
+                public void onResponse(Call<LoginResponseDto> call, Response<LoginResponseDto> response) {
                     if (response.isSuccessful()) {
-                        JsonObject res = response.body();
+                        LoginResponseDto res = response.body();
                         Log.e("[findpwFm]", "새비밀번호변경완료클릭 onResponse: 통신성공, 결과는: "+ res.toString() );
 
-                        if (res.get("result").getAsBoolean()){
-                            Toast.makeText(getActivity(), res.get("msg").getAsString(), Toast.LENGTH_SHORT).show();
+                        if (res.isResult()){
+                            Toast.makeText(getActivity(), res.getMsg(), Toast.LENGTH_SHORT).show();
                             NavHostFragment.findNavController(FindPwFm.this).navigate(R.id.action_global_loginMainFm);
 
                         } else {
-                            Toast.makeText(getActivity(), res.get("msg").getAsString(), Toast.LENGTH_SHORT).show();
+                            Toast.makeText(getActivity(), res.getMsg(), Toast.LENGTH_SHORT).show();
                         }
                     }
                 }
 
                 @Override
-                public void onFailure(Call<JsonObject> call, Throwable t) {
+                public void onFailure(Call<LoginResponseDto> call, Throwable t) {
                     Log.e("[findpwFm]", "새비밀번호변경완료클릭 onFailure: "+ t.getMessage() );
                 }
             });

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/login/JoinFm.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/login/JoinFm.java
@@ -22,7 +22,7 @@ import jm.preversion.biblewith.MyApp;
 import jm.preversion.biblewith.R;
 import jm.preversion.biblewith.databinding.LoginJoinFmBinding;
 import jm.preversion.biblewith.util.GmailSender;
-import com.google.gson.JsonObject;
+import jm.preversion.biblewith.login.dto.LoginResponseDto;
 
 import java.util.HashMap;
 
@@ -67,15 +67,15 @@ public class JoinFm extends Fragment {
         binding.joinEmailSendBt.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                loginVm.이메일중복검사통신(binding.joinEmailInput.getText().toString()).enqueue(new Callback<JsonObject>() {
+                loginVm.이메일중복검사통신(binding.joinEmailInput.getText().toString()).enqueue(new Callback<LoginResponseDto>() {
                     @Override
-                    public void onResponse(Call<JsonObject> call, Response<JsonObject> response) {
+                    public void onResponse(Call<LoginResponseDto> call, Response<LoginResponseDto> response) {
                         if (response.isSuccessful()) {
-                            JsonObject res = response.body();
+                            LoginResponseDto res = response.body();
                             Log.e("[JoinFm]", "이메일중복검사통신 onResponse: 통신성공, 결과는: "+ res.toString() );
 
                             //검사한 이메일이 존재하지않으면 인증메일을 바로보내고, 존재하면 toast 로 '사용중' 이라고 띄운다.
-                            if (res.get("result").getAsBoolean()){
+                            if (res.isResult()){
                                 Toast.makeText(getActivity(), "인증 메일을 보냈습니다.", Toast.LENGTH_SHORT).show();
                                 // todo: 인증메일 보내기 smtp
                                 인증메일보내기(binding.joinEmailInput.getText().toString());
@@ -94,7 +94,7 @@ public class JoinFm extends Fragment {
                         }
                     }
                     @Override
-                    public void onFailure(Call<JsonObject> call, Throwable t) {
+                    public void onFailure(Call<LoginResponseDto> call, Throwable t) {
                         Log.e("[JoinFm]", "이메일중복검사통신 onFailure: "+ t.getMessage() );
                     }
                 });
@@ -128,16 +128,16 @@ public class JoinFm extends Fragment {
             infoMap.put("user_pwdc",binding.joinPwVerifyInput.getText().toString());
             infoMap.put("user_nick",binding.joinNicknameInput.getText().toString());
             infoMap.put("user_name",binding.joinNameInput.getText().toString());
-            loginVm.회원가입(infoMap).enqueue(new Callback<JsonObject>() {
+            loginVm.회원가입(infoMap).enqueue(new Callback<LoginResponseDto>() {
                 @Override
-                public void onResponse(Call<JsonObject> call, Response<JsonObject> response) {
+                public void onResponse(Call<LoginResponseDto> call, Response<LoginResponseDto> response) {
                     Log.e("[JoinFm]", "회원가입 onResponse: 통신성공, code는: "+ response.code() );
                     if (response.isSuccessful()) {
-                        JsonObject res = response.body();
+                        LoginResponseDto res = response.body();
                         Log.e("[JoinFm]", "회원가입 onResponse: 통신성공, body는: "+ res.toString() );
 
-                        if (res.get("result").getAsBoolean()){
-                            Toast.makeText(getActivity(), res.get("msg").getAsString(), Toast.LENGTH_SHORT).show();
+                        if (res.isResult()){
+                            Toast.makeText(getActivity(), res.getMsg(), Toast.LENGTH_SHORT).show();
                             NavHostFragment.findNavController(JoinFm.this).navigate(R.id.action_global_loginMainFm);
 
                         } else {
@@ -148,7 +148,7 @@ public class JoinFm extends Fragment {
                 }
 
                 @Override
-                public void onFailure(Call<JsonObject> call, Throwable t) {
+                public void onFailure(Call<LoginResponseDto> call, Throwable t) {
                     Log.e("[JoinFm]", "이메일중복검사통신 onFailure: "+ t.getMessage() );
                 }
             });

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/login/LoginVm.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/login/LoginVm.java
@@ -4,7 +4,7 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 import jm.preversion.biblewith.util.Http;
-import com.google.gson.JsonObject;
+import jm.preversion.biblewith.login.dto.LoginResponseDto;
 
 import java.util.HashMap;
 
@@ -46,17 +46,17 @@ public class LoginVm extends ViewModel {
 
 
 
-    public Call<JsonObject> 이메일중복검사통신(String email) {
+    public Call<LoginResponseDto> 이메일중복검사통신(String email) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpLogin httpLogin = retrofit.create(Http.HttpLogin.class); //로그인을 위한 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpLogin.isEmailRedundant(email);        //call로 비동기 통신 가능하다.
+        Call<LoginResponseDto> call = httpLogin.isEmailRedundant(email);        //call로 비동기 통신 가능하다.
         return call;
     }
 
-    public Call<JsonObject> 회원가입(HashMap<String, String> info) {
+    public Call<LoginResponseDto> 회원가입(HashMap<String, String> info) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpLogin httpLogin = retrofit.create(Http.HttpLogin.class); //로그인을 위한 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpLogin.joinComplete(
+        Call<LoginResponseDto> call = httpLogin.joinComplete(
                 info.get("user_email"),
                 info.get("user_pwd"),
                 info.get("user_pwdc"),
@@ -66,20 +66,20 @@ public class LoginVm extends ViewModel {
         return call;
     }
 
-    public Call<JsonObject> 비번찾기인증번호발송클릭(HashMap<String, String> info) {
+    public Call<LoginResponseDto> 비번찾기인증번호발송클릭(HashMap<String, String> info) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpLogin httpLogin = retrofit.create(Http.HttpLogin.class); //로그인을 위한 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpLogin.findpwMailSend(
+        Call<LoginResponseDto> call = httpLogin.findpwMailSend(
                 info.get("user_name"),
                 info.get("user_email")
         );
         return call;
     }
 
-    public Call<JsonObject> 인증번호확인클릭(HashMap<String, String> info) {
+    public Call<LoginResponseDto> 인증번호확인클릭(HashMap<String, String> info) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpLogin httpLogin = retrofit.create(Http.HttpLogin.class); //로그인을 위한 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpLogin.findpwMailVnumConfirm(
+        Call<LoginResponseDto> call = httpLogin.findpwMailVnumConfirm(
                 info.get("findpw_number"),
                 info.get("name"),
                 info.get("email")
@@ -88,10 +88,10 @@ public class LoginVm extends ViewModel {
     }
 
 
-    public Call<JsonObject> 새비밀번호변경완료클릭(HashMap<String, String> info) {
+    public Call<LoginResponseDto> 새비밀번호변경완료클릭(HashMap<String, String> info) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpLogin httpLogin = retrofit.create(Http.HttpLogin.class); //로그인을 위한 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpLogin.findpwNewPw(
+        Call<LoginResponseDto> call = httpLogin.findpwNewPw(
                 info.get("user_email"),
                 info.get("user_pwd")
         );

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/login/dto/LoginResponseDto.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/login/dto/LoginResponseDto.java
@@ -1,0 +1,38 @@
+package jm.preversion.biblewith.login.dto;
+
+public class LoginResponseDto {
+    private boolean result;
+    private String msg;
+
+    public LoginResponseDto() {
+    }
+
+    public LoginResponseDto(boolean result, String msg) {
+        this.result = result;
+        this.msg = msg;
+    }
+
+    public boolean isResult() {
+        return result;
+    }
+
+    public void setResult(boolean result) {
+        this.result = result;
+    }
+
+    public String getMsg() {
+        return msg;
+    }
+
+    public void setMsg(String msg) {
+        this.msg = msg;
+    }
+
+    @Override
+    public String toString() {
+        return "LoginResponseDto{" +
+                "result=" + result +
+                ", msg='" + msg + '\'' +
+                '}';
+    }
+}

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/util/Http.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/util/Http.java
@@ -6,6 +6,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import jm.preversion.biblewith.login.dto.LoginResponseDto;
 import com.localebro.okhttpprofiler.OkHttpProfilerInterceptor;
 
 import java.util.List;
@@ -71,11 +72,11 @@ public class Http {
     public interface HttpLogin{
         // 이메일 중복확인 통신
         @GET("home/isEmailRedundant")
-        Call<JsonObject> isEmailRedundant(@Query("user_email") String user_email );
+        Call<LoginResponseDto> isEmailRedundant(@Query("user_email") String user_email );
 
         //회원가입 버튼 클릭시 - 신청
         @GET("home/join")
-        Call<JsonObject> joinComplete(@Query("user_email") String user_email,
+        Call<LoginResponseDto> joinComplete(@Query("user_email") String user_email,
                                           @Query("user_pwd") String user_pwd,
                                           @Query("user_pwdc") String user_pwdc,
                                           @Query("user_nick") String user_nick,
@@ -84,20 +85,20 @@ public class Http {
 
         //비번찾기 이메일 인증번호 발송 버튼 클릭시 -
         @GET("home/findpwMailSend")
-        Call<JsonObject> findpwMailSend(@Query("user_name") String user_name,
+        Call<LoginResponseDto> findpwMailSend(@Query("user_name") String user_name,
                                         @Query("user_email") String user_email
         );
 
         //비번찾기 인증번호 확인 버튼 클릭시
         @GET("home/findpwMailVnumConfirm")
-        Call<JsonObject> findpwMailVnumConfirm(@Query("findpw_number") String findpw_number,
+        Call<LoginResponseDto> findpwMailVnumConfirm(@Query("findpw_number") String findpw_number,
                                                @Query("name") String name,
                                                @Query("email") String email
         );
 
         //새 비밀번호 설정 완료 버튼 클릭시
         @GET("home/findpwNewPw")
-        Call<JsonObject> findpwNewPw(@Query("user_email") String user_email, @Query("user_pwd") String user_pwd   );
+        Call<LoginResponseDto> findpwNewPw(@Query("user_email") String user_email, @Query("user_pwd") String user_pwd   );
 
         //로그인 버튼 클릭시
         @GET("home/login")
@@ -117,7 +118,7 @@ public class Http {
                                      @Part/*("group_main_image")*/ MultipartBody.Part userImage);
 
         @POST("home/nickModify")
-        Call<JsonObject> 유저닉네임수정( @Query("user_no") int user_no,
+        Call<LoginResponseDto> 유저닉네임수정( @Query("user_no") int user_no,
                                   @Query("user_nick") String user_nick
         );
     }


### PR DESCRIPTION
## Summary
- create `LoginResponseDto` for standard login responses
- update `HttpLogin` interface to return `LoginResponseDto`
- adjust `LoginVm` methods for new DTO usage
- refactor `JoinFm` and `FindPwFm` to read results from DTO

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844588eabb4832b81d47647e75e289b