### PR TITLE
Refactor group APIs to use DTOs

### DIFF
--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/GroupListRva.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/GroupListRva.kt
@@ -12,7 +12,7 @@ import jm.preversion.biblewith.databinding.GroupListFmVhBinding
 import jm.preversion.biblewith.moreinfo.MyNoteRvaInner
 import jm.preversion.biblewith.util.Http.UPLOADS_URL
 import jm.preversion.biblewith.util.ImageHelper
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.group.dto.GroupInfoDto
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -24,11 +24,11 @@ class GroupListRva(val groupVm: GroupVm, val groupListFm: GroupListFm) : Recycle
     }
 
     override fun onBindViewHolder(holder: GroupListRva.GroupListFmVh, position: Int) {
-        holder.bind(groupVm.groupL[position] as JsonObject)
+        holder.bind(groupVm.groupL[position])
     }
 
     override fun getItemCount(): Int {
-        return groupVm.groupL.size()
+        return groupVm.groupL.size
     }
 
 
@@ -41,15 +41,15 @@ class GroupListRva(val groupVm: GroupVm, val groupListFm: GroupListFm) : Recycle
         }
 
         //mItem -- 모임목록가져오기()
-        fun bind(mItem: JsonObject) {
+        fun bind(mItem: GroupInfoDto) {
 //            this.mItem = mItem;
 //            binding.groupIvInCardview.setImageURI(Uri.parse(UPLOADS_URL + mItem.get("group_main_image").asString))
-            ImageHelper.getImageUsingGlide(groupListFm.requireContext(), mItem.get("group_main_image").asString, binding.groupIvInCardview)
-            binding.myNoteFmVhContentTv.text = mItem.get("group_name").asString
+            ImageHelper.getImageUsingGlide(groupListFm.requireContext(), mItem.groupMainImage, binding.groupIvInCardview)
+            binding.myNoteFmVhContentTv.text = mItem.groupName
 
             //홀더 클릭시 해당하는 모임 상세 페이지로 이동
             binding.root.setOnClickListener(View.OnClickListener {
-                groupVm.currentGroupIn = mItem.get("group_no").asInt
+                groupVm.currentGroupIn = mItem.groupNo
 //                CoroutineScope(Dispatchers.Main).launch {
 //                    //모임상세불러오기() - groupInfo 가 챌린지목록가져오기()안에서 참조되기 때문에 모임상세불러오기()의 안전(임시)?한 로딩을 위해 약간의 지연을 둠
 //                    //원래는 모임상세불러오기() 자체가 코루틴등으로 안전한 비동기 로직이 수행되어야함..

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/GroupVm.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/GroupVm.kt
@@ -12,6 +12,13 @@ import jm.preversion.biblewith.util.Http
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import jm.preversion.biblewith.group.dto.GroupListResponse
+import jm.preversion.biblewith.group.dto.GroupInfoDto
+import jm.preversion.biblewith.group.dto.GboardDto
+import jm.preversion.biblewith.group.dto.GboardReplyDto
+import jm.preversion.biblewith.group.dto.GroupMemberDto
+import jm.preversion.biblewith.group.dto.GroupDetailResponse
+import jm.preversion.biblewith.group.dto.GboardDetailResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.Call
@@ -27,19 +34,19 @@ class GroupVm : ViewModel() {
     val host = Http.HOST_IP
     val gson = GsonBuilder().setPrettyPrinting().create()
 
-    var groupL = JsonArray() //모임 목록 - 모임목록가져오기()
-    var liveGroupL = MutableLiveData<JsonArray>()
-    var gboardL = JsonArray() //모임 상세페이지 게시물 목록 - 모임상세불러오기()
-    var liveGboardL = MutableLiveData<JsonArray>()
-    var memberL = JsonArray() //모임 상세페이지 멤버 목록 - 모임상세불러오기(), 모임멤버목록로드(), 모임멤버추방,탈퇴,검색()
-    var liveMemberL = MutableLiveData<JsonArray>()
-    var groupInfo = JsonObject() //모임 상세페이지 모임요약 정보 - 모임상세불러오기()에서 불러옴
-    var liveGroupInfo = MutableLiveData<JsonObject>()
+    var groupL: List<GroupInfoDto> = emptyList() //모임 목록 - 모임목록가져오기()
+    var liveGroupL = MutableLiveData<List<GroupInfoDto>>()
+    var gboardL: List<GboardDto> = emptyList() //모임 상세페이지 게시물 목록 - 모임상세불러오기()
+    var liveGboardL = MutableLiveData<List<GboardDto>>()
+    var memberL: List<GroupMemberDto> = emptyList() //모임 상세페이지 멤버 목록
+    var liveMemberL = MutableLiveData<List<GroupMemberDto>>()
+    var groupInfo: GroupInfoDto? = null //모임 상세페이지 모임요약 정보
+    var liveGroupInfo = MutableLiveData<GroupInfoDto>()
 
-    var gboardInfo = JsonObject() //모임 게시물 디테일 정보 - 모임글상세가져오기() - 내용(글,좋아요수,히트수,) + 이미지목록 + 댓글 목록
-    var liveGboardInfo = MutableLiveData<JsonObject>()
-    var gboardReplyL = JsonArray() //모임 게시물 디테일 댓글 정보 - 모임글상세가져오기()
-    var liveGboardReplyL = MutableLiveData<JsonArray>()
+    var gboardInfo: GboardDto? = null //모임 게시물 디테일 정보
+    var liveGboardInfo = MutableLiveData<GboardDto>()
+    var gboardReplyL: List<GboardReplyDto> = emptyList() //모임 게시물 디테일 댓글 정보
+    var liveGboardReplyL = MutableLiveData<List<GboardReplyDto>>()
 
 
     var sortState = "name"  //모임목록페이지 정렬 초기값 모임이름순
@@ -136,21 +143,20 @@ class GroupVm : ViewModel() {
     }
 
 
-    fun 모임목록가져오기(user_no :Int ,  isExeInVm: Boolean): Call<JsonObject>? {
+    fun 모임목록가져오기(user_no :Int ,  isExeInVm: Boolean): Call<GroupListResponse>? {
         val retrofit = Http.getRetrofitInstance(host)
         val httpGroup = retrofit.create(Http.HttpGroup::class.java) // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
         val call = httpGroup.getGroupL(user_no, sortState)
         if (isExeInVm) { //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
-            call.enqueue(object : Callback<JsonObject?> {
-                override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
+            call.enqueue(object : Callback<GroupListResponse> {
+                override fun onResponse(call: Call<GroupListResponse>, response: Response<GroupListResponse>) {
                     if (response.isSuccessful) {
                         val res = response.body()!!
-//                        Log.e("[GroupVm]", "모임목록가져오기 onResponse: $res")
-                        groupL = res.get("result").asJsonArray
+                        groupL = res.result
                         liveGroupL.value = groupL
                     }
                 }
-                override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
+                override fun onFailure(call: Call<GroupListResponse>, t: Throwable) {
                     Log.e("[GroupVm]", "모임목록가져오기 onFailure: " + t.message)
                 }
             })
@@ -159,52 +165,50 @@ class GroupVm : ViewModel() {
     }
 
     // 모임상세 목록을 가져옴 - 게시물리스트, 멤버리스트, 모임정보 ...
-    fun 모임상세불러오기(isExeInVm: Boolean): Call<JsonObject>? {
+    fun 모임상세불러오기(isExeInVm: Boolean): Call<GroupDetailResponse>? {
         val retrofit = Http.getRetrofitInstance(host)
         val httpGroup = retrofit.create(Http.HttpGroup::class.java) // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
         val call = httpGroup.getGroupIn(currentGroupIn, sortStateGroupIn, MyApp.userInfo.user_no)
         if (isExeInVm) { //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
-            call.enqueue(object : Callback<JsonObject?> {
-                override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
+            call.enqueue(object : Callback<GroupDetailResponse> {
+                override fun onResponse(call: Call<GroupDetailResponse>, response: Response<GroupDetailResponse>) {
                     if (response.isSuccessful) {
                         val res = response.body()!!
-//                        Log.e("[GroupVm]", "모임상세불러오기 onResponse: ${gson.toJson(res)}")
-                        gboardL = res.get("result").asJsonObject.get("gboardL").asJsonArray
+                        gboardL = res.result.gboardL
                         liveGboardL.value = gboardL
-                        memberL = res.get("result").asJsonObject.get("memberL").asJsonArray
+                        memberL = res.result.memberL
                         liveMemberL.value = memberL
-                        groupInfo = res.get("result").asJsonObject.get("0").asJsonObject
+                        groupInfo = res.result.groupInfo
                         liveGroupInfo.value = groupInfo
                     }
                 }
-                override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
+                override fun onFailure(call: Call<GroupDetailResponse>, t: Throwable) {
                     Log.e("[GroupVm]", "모임상세불러오기 onFailure: " + t.message)
                 }
             })
         }
         return call
     }
-    suspend fun 모임상세불러오기2(isExeInVm: Boolean): Call<JsonObject>? {
+    suspend fun 모임상세불러오기2(isExeInVm: Boolean): Call<GroupDetailResponse>? {
         val retrofit = Http.getRetrofitInstance(host)
         val httpGroup = retrofit.create(Http.HttpGroup::class.java) // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
         val call = httpGroup.getGroupIn(currentGroupIn, sortStateGroupIn, MyApp.userInfo.user_no)
         if (isExeInVm) { //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
             val resp = suspendCoroutine { cont: Continuation<Unit> ->
-                call.enqueue(object : Callback<JsonObject?> {
-                    override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
+                call.enqueue(object : Callback<GroupDetailResponse> {
+                    override fun onResponse(call: Call<GroupDetailResponse>, response: Response<GroupDetailResponse>) {
                         if (response.isSuccessful) {
                             val res = response.body()!!
-    //                        Log.e("[GroupVm]", "모임상세불러오기 onResponse: ${gson.toJson(res)}")
-                            gboardL = res.get("result").asJsonObject.get("gboardL").asJsonArray
+                            gboardL = res.result.gboardL
                             liveGboardL.value = gboardL
-                            memberL = res.get("result").asJsonObject.get("memberL").asJsonArray
+                            memberL = res.result.memberL
                             liveMemberL.value = memberL
-                            groupInfo = res.get("result").asJsonObject.get("0").asJsonObject
+                            groupInfo = res.result.groupInfo
                             liveGroupInfo.value = groupInfo
                             cont.resumeWith(Result.success(Unit))
                         }
                     }
-                    override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
+                    override fun onFailure(call: Call<GroupDetailResponse>, t: Throwable) {
                         Log.e("[GroupVm]", "모임상세불러오기 onFailure: " + t.message)
                     }
                 })
@@ -272,25 +276,25 @@ class GroupVm : ViewModel() {
         return call
     }
 
-     suspend fun 모임글상세가져오기(gboard_no: Int, whereIs : String, isExeInVm: Boolean): Call<JsonObject>? {
+     suspend fun 모임글상세가져오기(gboard_no: Int, whereIs : String, isExeInVm: Boolean): Call<GboardDetailResponse>? {
         val retrofit = Http.getRetrofitInstance(host)
         val httpGroup = retrofit.create(Http.HttpGroup::class.java) // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
         val call = httpGroup.getGboardDetail(gboard_no, whereIs, MyApp.userInfo.user_no)
         if (isExeInVm) { //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
             val resp = suspendCoroutine { cont: Continuation<Unit> ->
-                call.enqueue(object : Callback<JsonObject?> {
-                    override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
+                call.enqueue(object : Callback<GboardDetailResponse> {
+                    override fun onResponse(call: Call<GboardDetailResponse>, response: Response<GboardDetailResponse>) {
                         if (response.isSuccessful) {
                             val res = response.body()!!
-                            gboardInfo = res.get("result").asJsonObject.get("gboardInfo").asJsonObject
+                            gboardInfo = res.result.gboardInfo
                             liveGboardInfo.value = gboardInfo
-                            gboardReplyL = res.get("result").asJsonObject.get("gboardReplyL").asJsonArray
+                            gboardReplyL = res.result.gboardReplyL
                             liveGboardReplyL.value = gboardReplyL
 //                            Log.e("[GroupVm]", "모임글상세가져오기 완료: $res")
                             cont.resumeWith(Result.success(Unit))
                         }
                     }
-                    override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
+                    override fun onFailure(call: Call<GboardDetailResponse>, t: Throwable) {
                         Log.e("[GroupVm]", "모임글상세가져오기 onFailure: " + t.message)
                     }
                 })

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/ApiResponse.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/ApiResponse.kt
@@ -1,0 +1,11 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/**
+ * 공통 API 응답 래퍼
+ */
+data class ApiResponse<T>(
+    @SerializedName("result") val result: T?,
+    @SerializedName("msg") val msg: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardDetailDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardDetailDto.kt
@@ -1,0 +1,9 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 게시물 상세 result */
+data class GboardDetailDto(
+    @SerializedName("gboardInfo") val gboardInfo: GboardDto,
+    @SerializedName("gboardReplyL") val gboardReplyL: List<GboardReplyDto>
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardDetailResponse.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardDetailResponse.kt
@@ -1,0 +1,9 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 게시물 상세 응답 */
+data class GboardDetailResponse(
+    @SerializedName("result") val result: GboardDetailDto,
+    @SerializedName("msg") val msg: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardDto.kt
@@ -1,0 +1,24 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 게시물 DTO */
+data class GboardDto(
+    @SerializedName("gboard_no") val gboardNo: Int,
+    @SerializedName("group_no") val groupNo: Int,
+    @SerializedName("user_no") val userNo: Int,
+    @SerializedName("gboard_title") val gboardTitle: String?,
+    @SerializedName("gboard_content") val gboardContent: String,
+    @SerializedName("create_date") val createDate: String?,
+    @SerializedName("user_email") val userEmail: String?,
+    @SerializedName("user_pwd") val userPwd: String?,
+    @SerializedName("user_nick") val userNick: String,
+    @SerializedName("user_create_date") val userCreateDate: String?,
+    @SerializedName("user_name") val userName: String?,
+    @SerializedName("user_image") val userImage: String?,
+    @SerializedName("is_like") val isLike: Boolean?,
+    @SerializedName("gboard_like_count") val gboardLikeCount: String?,
+    @SerializedName("reply_count") val replyCount: String?,
+    @SerializedName("gboard_image") val gboardImage: List<GboardImageDto> = emptyList(),
+    @SerializedName("replyL") val replyL: List<GboardReplyDto>? = null
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardImageDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardImageDto.kt
@@ -1,0 +1,13 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 게시물 이미지 DTO */
+data class GboardImageDto(
+    @SerializedName("gboard_image_no") val imageNo: Int,
+    @SerializedName("gboard_no") val gboardNo: Int,
+    @SerializedName("original_file_name") val originalFileName: String?,
+    @SerializedName("stored_file_name") val storedFileName: String?,
+    @SerializedName("file_size") val fileSize: String?,
+    @SerializedName("create_date") val createDate: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardReplyDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GboardReplyDto.kt
@@ -1,0 +1,17 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 게시물 댓글 DTO */
+data class GboardReplyDto(
+    @SerializedName("reply_no") val replyNo: Int,
+    @SerializedName("gboard_no") val gboardNo: Int,
+    @SerializedName("user_no") val userNo: Int,
+    @SerializedName("reply_content") val replyContent: String,
+    @SerializedName("reply_writedate") val replyWriteDate: String,
+    @SerializedName("parent_reply_no") val parentReplyNo: Int?,
+    @SerializedName("parent_nick") val parentNick: String?,
+    @SerializedName("reply_group") val replyGroup: Int?,
+    @SerializedName("user_nick") val userNick: String,
+    @SerializedName("user_image") val userImage: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupDetailDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupDetailDto.kt
@@ -1,0 +1,10 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 모임 상세 응답 result */
+data class GroupDetailDto(
+    @SerializedName("0") val groupInfo: GroupInfoDto,
+    @SerializedName("gboardL") val gboardL: List<GboardDto>,
+    @SerializedName("memberL") val memberL: List<GroupMemberDto>
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupDetailResponse.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupDetailResponse.kt
@@ -1,0 +1,9 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 모임 상세 응답 래퍼 */
+data class GroupDetailResponse(
+    @SerializedName("result") val result: GroupDetailDto,
+    @SerializedName("msg") val msg: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupInfoDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupInfoDto.kt
@@ -1,0 +1,14 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 모임 정보 DTO */
+data class GroupInfoDto(
+    @SerializedName("group_no") val groupNo: Int,
+    @SerializedName("chat_room_no") val chatRoomNo: Int?,
+    @SerializedName("user_no") val userNo: Int,
+    @SerializedName("group_name") val groupName: String,
+    @SerializedName("group_desc") val groupDesc: String?,
+    @SerializedName("group_main_image") val groupMainImage: String?,
+    @SerializedName("create_date") val createDate: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupListResponse.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupListResponse.kt
@@ -1,0 +1,9 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 모임 목록 응답 래퍼 */
+data class GroupListResponse(
+    @SerializedName("result") val result: List<GroupInfoDto>,
+    @SerializedName("msg") val msg: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupMemberDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/group/dto/GroupMemberDto.kt
@@ -1,0 +1,16 @@
+package jm.preversion.biblewith.group.dto
+
+import com.google.gson.annotations.SerializedName
+
+/** 모임 멤버 DTO */
+data class GroupMemberDto(
+    @SerializedName("group_no") val groupNo: Int,
+    @SerializedName("user_no") val userNo: Int,
+    @SerializedName("user_email") val userEmail: String?,
+    @SerializedName("user_pwd") val userPwd: String?,
+    @SerializedName("user_nick") val userNick: String,
+    @SerializedName("user_create_date") val userCreateDate: String?,
+    @SerializedName("user_name") val userName: String?,
+    @SerializedName("user_image") val userImage: String?,
+    @SerializedName("join_date") val joinDate: String?
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/util/Http.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/util/Http.java
@@ -7,6 +7,9 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.localebro.okhttpprofiler.OkHttpProfilerInterceptor;
+import jm.preversion.biblewith.group.dto.GroupListResponse;
+import jm.preversion.biblewith.group.dto.GroupDetailResponse;
+import jm.preversion.biblewith.group.dto.GboardDetailResponse;
 
 import java.util.List;
 import java.util.Map;
@@ -212,13 +215,13 @@ public class Http {
         //모임 목록 가져오기
         @Headers("content-type: application/json")
         @POST("group/getGroupL")
-        Call<JsonObject> getGroupL(@Query("user_no") int userNo, @Query("sortState") String sortState);
+        Call<GroupListResponse> getGroupL(@Query("user_no") int userNo, @Query("sortState") String sortState);
 
 
         //모임 상세 가져오기
         @Headers("content-type: application/json")
         @POST("group/getGroupIn")
-        Call<JsonObject> getGroupIn(@Query("group_no") int currentGroupIn, @Query("sortStateGroupIn") String sortStateGroupIn, @Query("user_no") int userNo);
+        Call<GroupDetailResponse> getGroupIn(@Query("group_no") int currentGroupIn, @Query("sortStateGroupIn") String sortStateGroupIn, @Query("user_no") int userNo);
 
         //모임 게시물 목록 가져오기
         @Headers("content-type: application/json")
@@ -245,7 +248,7 @@ public class Http {
         //모임 글 상세 가져오기
         @Headers("content-type: application/json")
         @POST("group/getGboardDetail")
-        Call<JsonObject> getGboardDetail(@Query("gboard_no") int gboard_no, @Query("whereIs") String whereIs, @Query("user_no") int userNo);
+        Call<GboardDetailResponse> getGboardDetail(@Query("gboard_no") int gboard_no, @Query("whereIs") String whereIs, @Query("user_no") int userNo);
 
         //모임 댓글 쓰기
         @Headers("content-type: application/json")


### PR DESCRIPTION
## Summary
- create typed DTOs for group-related APIs
- switch retrofit interface to return DTO wrappers
- refactor GroupVm properties and parsing logic
- update group list adapter to use DTO models

## Testing
- `git commit -m "Add DTOs and refactor group API usage"`

------
https://chatgpt.com/codex/tasks/task_e_68431e7accf4832bbb88fd1c057df7e0