### PR TITLE
Refactor note/home APIs to DTO

### DIFF
--- a/androidclient/app/src/main/java/jm/preversion/biblewith/bible/BibleVm.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/bible/BibleVm.java
@@ -12,10 +12,11 @@ import androidx.lifecycle.ViewModel;
 import jm.preversion.biblewith.MyApp;
 import jm.preversion.biblewith.bible.dto.BibleBtsDto;
 import jm.preversion.biblewith.bible.dto.BibleDto;
+import jm.preversion.biblewith.bible.dto.NoteDto;
+import jm.preversion.biblewith.bible.dto.ResultDto;
 import jm.preversion.biblewith.util.Http;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -35,20 +36,20 @@ public class BibleVm extends ViewModel {
     public MutableLiveData<List<BibleDto>> liveBookL = new MutableLiveData<>(); //책이름 검색에서 쓰임
     public MutableLiveData<List<BibleDto>> liveVerseL = new MutableLiveData<>();
     public MutableLiveData<List<BibleDto>> liveHighL = new MutableLiveData<>();
-    public MutableLiveData<JsonArray> liveNoteL = new MutableLiveData<>();
+    public MutableLiveData<List<NoteDto>> liveNoteL = new MutableLiveData<>();
     public MutableLiveData<int[]> live책장번호 = new MutableLiveData<>();
     public List<BibleDto> bookL = new ArrayList<BibleDto>(); //책이름목록
     public List<BibleDto> bookLForSearch = new ArrayList<BibleDto>(); //책이름목록 - 툴바 검색용: 변화없이 고정값을 가져야함
     public List<BibleDto> chapterL = new ArrayList<BibleDto>(); //장목록
     public List<BibleDto> verseL = new ArrayList<BibleDto>(); //절목록
     public List<BibleDto> highL = new ArrayList<BibleDto>(); //유저 하이라이트 목록
-    public JsonArray noteL = new JsonArray(); //유저 노트 목록 - 노트목록가져오기()에서 가져옴
+    public List<NoteDto> noteL = new ArrayList<>(); //유저 노트 목록 - 노트목록가져오기()에서 가져옴
     public List<BibleBtsDto> colorL = new ArrayList<BibleBtsDto>(); //BtsR의 하이라이트 색깔 목록
 
 
     public int[] 책장번호 = new int[]{1, 1, 1}; //todo 추후 유저테이블에 3개의 컬럼 추가후 이 데이터(마지막봤던)를 서버로 insert해줌
     public boolean onceExecuted = false; //한번실행 후 스크롤 처리 x - BibleVerseFm
-    public JsonObject noteUpdateO = new JsonObject(); //노트 수정용 - 구조내용: note table + note_verseL:Array(noteverse & bible_korHRV)
+    public NoteDto noteUpdateO = null; //노트 수정용 - 구조내용: note table + note_verseL:Array(noteverse & bible_korHRV)
     public JsonObject tempObj = new JsonObject(); //임시데이터 - 자유롭게 사용가능 - 임시라 1회용 명령에만 쓰임 반드시 작업을 한번에 깔끔히 마무리해야함! - 툴바책검색(bookSearchText)
 
     {
@@ -333,22 +334,22 @@ public class BibleVm extends ViewModel {
         return call;
     }
 
-    public Call<JsonArray> 노트목록가져오기(Boolean isExeInVm) {
+    public Call<List<NoteDto>> 노트목록가져오기(Boolean isExeInVm) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpBible httpBible = retrofit.create(Http.HttpBible.class); // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonArray> call = httpBible.getNoteList(MyApp.userInfo.getUser_no());
+        Call<List<NoteDto>> call = httpBible.getNoteList(MyApp.userInfo.getUser_no());
         if(isExeInVm) { //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
-            call.enqueue(new Callback<JsonArray>() {
+            call.enqueue(new Callback<List<NoteDto>>() {
                 @Override
-                public void onResponse(@NonNull Call<JsonArray> call, @NonNull Response<JsonArray> response) {
+                public void onResponse(@NonNull Call<List<NoteDto>> call, @NonNull Response<List<NoteDto>> response) {
                     if (response.isSuccessful()) {
-                        JsonArray res = response.body();
+                        List<NoteDto> res = response.body();
                         noteL = res;
                         liveNoteL.setValue(noteL);
                     }
                 }
                 @Override
-                public void onFailure(Call<JsonArray> call, Throwable t) {
+                public void onFailure(Call<List<NoteDto>> call, Throwable t) {
                     Log.e("[BibleVm]", "노트목록가져오기 onFailure: "+ t.getMessage() );
 
                 }
@@ -357,22 +358,22 @@ public class BibleVm extends ViewModel {
         return call;
     }
 
-    public Call<JsonObject> 노트추가(JsonObject noteinfo, Boolean isExeInVm) {
+    public Call<ResultDto> 노트추가(JsonObject noteinfo, Boolean isExeInVm) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpBible httpBible = retrofit.create(Http.HttpBible.class); // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpBible.getNoteAdd(noteinfo);
+        Call<ResultDto> call = httpBible.getNoteAdd(noteinfo);
         if(isExeInVm){ //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
-            call.enqueue(new Callback<JsonObject>() {
+            call.enqueue(new Callback<ResultDto>() {
                 @Override
-                public void onResponse(@NonNull Call<JsonObject> call, @NonNull Response<JsonObject> response) {
+                public void onResponse(@NonNull Call<ResultDto> call, @NonNull Response<ResultDto> response) {
                     if (response.isSuccessful()) {
-                        JsonObject res = response.body();
-    //                    highL = res;
-    //                    liveHighL.setValue(highL);
+                        ResultDto res = response.body();
+                        //                    highL = res;
+                        //                    liveHighL.setValue(highL);
                     }
                 }
                 @Override
-                public void onFailure(Call<JsonObject> call, Throwable t) {
+                public void onFailure(Call<ResultDto> call, Throwable t) {
                     Log.e("[BibleVm]", "노트추가 onFailure: "+ t.getMessage() );
 
                 }
@@ -381,22 +382,22 @@ public class BibleVm extends ViewModel {
         return call;
     }
 
-    public Call<JsonObject> 노트수정(JsonObject noteinfo, Boolean isExeInVm) {
+    public Call<ResultDto> 노트수정(JsonObject noteinfo, Boolean isExeInVm) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpBible httpBible = retrofit.create(Http.HttpBible.class); // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpBible.getNoteUpdate(noteinfo);
+        Call<ResultDto> call = httpBible.getNoteUpdate(noteinfo);
         if(isExeInVm){ //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
-            call.enqueue(new Callback<JsonObject>() {
+            call.enqueue(new Callback<ResultDto>() {
                 @Override
-                public void onResponse(@NonNull Call<JsonObject> call, @NonNull Response<JsonObject> response) {
+                public void onResponse(@NonNull Call<ResultDto> call, @NonNull Response<ResultDto> response) {
                     if (response.isSuccessful()) {
-                        JsonObject res = response.body();
+                        ResultDto res = response.body();
                         //                    highL = res;
                         //                    liveHighL.setValue(highL);
                     }
                 }
                 @Override
-                public void onFailure(Call<JsonObject> call, Throwable t) {
+                public void onFailure(Call<ResultDto> call, Throwable t) {
                     Log.e("[BibleVm]", "노트수정 onFailure: "+ t.getMessage() );
 
                 }
@@ -405,20 +406,20 @@ public class BibleVm extends ViewModel {
         return call;
     }
 
-    public Call<JsonObject> 노트삭제(int note_no, Boolean isExeInVm) {
+    public Call<ResultDto> 노트삭제(int note_no, Boolean isExeInVm) {
         Retrofit retrofit = Http.getRetrofitInstance(host);
         Http.HttpBible httpBible = retrofit.create(Http.HttpBible.class); // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        Call<JsonObject> call = httpBible.deleteNote(note_no);
+        Call<ResultDto> call = httpBible.deleteNote(note_no);
         if(isExeInVm){ //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
-            call.enqueue(new Callback<JsonObject>() {
+            call.enqueue(new Callback<ResultDto>() {
                 @Override
-                public void onResponse(@NonNull Call<JsonObject> call, @NonNull Response<JsonObject> response) {
+                public void onResponse(@NonNull Call<ResultDto> call, @NonNull Response<ResultDto> response) {
                     if (response.isSuccessful()) {
-                        JsonObject res = response.body();
+                        ResultDto res = response.body();
                     }
                 }
                 @Override
-                public void onFailure(Call<JsonObject> call, Throwable t) {
+                public void onFailure(Call<ResultDto> call, Throwable t) {
                     Log.e("[BibleVm]", "노트삭제 onFailure: "+ t.getMessage() );
 
                 }

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/HomeVerseDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/HomeVerseDto.kt
@@ -1,0 +1,17 @@
+package jm.preversion.biblewith.bible.dto
+
+data class HomeVerseDto(
+    var result: VerseResult,
+    var msg: String
+)
+
+data class VerseResult(
+    var bible_no: Int,
+    var book: Int,
+    var chapter: Int,
+    var verse: Int,
+    var content: String,
+    var book_no: Int,
+    var book_name: String,
+    var book_category: String
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/NoteDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/NoteDto.kt
@@ -1,0 +1,9 @@
+package jm.preversion.biblewith.bible.dto
+
+data class NoteDto(
+    var note_no: Int,
+    var user_no: Int,
+    var note_content: String,
+    var note_date: String,
+    var note_verseL: List<NoteVerseDto>
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/NoteVerseDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/NoteVerseDto.kt
@@ -1,0 +1,11 @@
+package jm.preversion.biblewith.bible.dto
+
+data class NoteVerseDto(
+    var note_verse_no: Int?,
+    var note_no: Int?,
+    var bible_no: Int?,
+    var book: Int,
+    var chapter: Int,
+    var verse: Int,
+    var content: String
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/RandomImageDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/RandomImageDto.kt
@@ -1,0 +1,10 @@
+package jm.preversion.biblewith.bible.dto
+
+data class RandomImageDto(
+    var urls: Urls
+)
+
+data class Urls(
+    var regular: String,
+    var small: String
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/ResultDto.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/bible/dto/ResultDto.kt
@@ -1,0 +1,5 @@
+package jm.preversion.biblewith.bible.dto
+
+data class ResultDto(
+    var result: Boolean
+)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeFm.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeFm.kt
@@ -158,16 +158,16 @@ class HomeFm : Fragment() { //왜 커밋이 없어?
 
         //성경 일독 갱신
         homeVm.liveTodayVerse.observe(viewLifecycleOwner, Observer {
-            if (it.get("bible_no") != null) {
-                binding.verseTv.text = "${it.get("content").asString}"
-                binding.bookTv.text = "${it.get("book_name").asString} ${it.get("chapter").asString}:${it.get("verse").asString}"
+            if (it != null) {
+                binding.verseTv.text = it.result.content
+                binding.bookTv.text = "${it.result.book_name} ${it.result.chapter}:${it.result.verse}"
 //                binding.profileIv //이미지 바꿔주기
             }
         })
 
         //홈 이미지 Unsplash Api 랜덤 이미지 로드
         homeVm.liveUnsplashRandomL.observe(viewLifecycleOwner, Observer {
-            val profileSt = homeVm.unsplashRandomL.get(9).asJsonObject.get("urls").asJsonObject.get("regular").asString
+            val profileSt = homeVm.unsplashRandomL[9].urls.regular
             Log.e(tagName, "profileSt: $profileSt")
 
             ImageHelper.getImageUsingGlideForURI(requireActivity(), Uri.parse(profileSt), binding.profileIv)

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeFmImgRva.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeFmImgRva.kt
@@ -78,9 +78,9 @@ class HomeFmImgRva(val bibleVm: BibleVm, val homeVm: HomeVm, val homeFm: HomeFm)
                 intent.action = Intent.ACTION_EDIT
 //                intent.data = Uri.parse(mItem.get("urls").asJsonObject.get("regular").asString)
                 intent.data =  Uri.parse(mItem.urls.regular)
-                intent.putExtra("content", homeVm.todayVerse.asJsonObject.get("content").asString)
-                val send_st = "${homeVm.todayVerse.asJsonObject.get("book_name").asString} " +
-                        "${homeVm.todayVerse.asJsonObject.get("chapter").asString}:${homeVm.todayVerse.asJsonObject.get("verse").asString}"
+                intent.putExtra("content", homeVm.todayVerse?.result?.content)
+                val send_st = "${homeVm.todayVerse?.result?.book_name} " +
+                        "${homeVm.todayVerse?.result?.chapter}:${homeVm.todayVerse?.result?.verse}"
                 intent.putExtra("book", send_st)
 //                    Uri.parse(mItem.get("urls").asJsonObject.get("small").asString)
 

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeFmImgVpa.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeFmImgVpa.kt
@@ -54,9 +54,9 @@ class HomeFmImgVpa(val homeVm: HomeVm, val homeFm: HomeFm) : RecyclerView.Adapte
                 val intent = Intent(homeFm.requireActivity(), EditImageActivity::class.java)
                 intent.action = Intent.ACTION_EDIT
                 intent.data = Uri.parse(mItem.get("urls").asJsonObject.get("regular").asString)
-                intent.putExtra("content", homeVm.todayVerse.asJsonObject.get("content").asString)
-                val send_st = "${homeVm.todayVerse.asJsonObject.get("book_name").asString} " +
-                        "${homeVm.todayVerse.asJsonObject.get("chapter").asString}:${homeVm.todayVerse.asJsonObject.get("verse").asString}"
+                intent.putExtra("content", homeVm.todayVerse?.result?.content)
+                val send_st = "${homeVm.todayVerse?.result?.book_name} " +
+                        "${homeVm.todayVerse?.result?.chapter}:${homeVm.todayVerse?.result?.verse}"
                 intent.putExtra("book", send_st)
 //                    Uri.parse(mItem.get("urls").asJsonObject.get("small").asString)
 

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeVm.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/home/HomeVm.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.LiveData
 import jm.preversion.biblewith.MyApp
 import jm.preversion.biblewith.util.Http
 import com.google.gson.Gson
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.bible.dto.HomeVerseDto
+import jm.preversion.biblewith.bible.dto.RandomImageDto
 import com.unsplash.pickerandroid.photopicker.data.UnsplashPhoto
 import okhttp3.MultipartBody
 import retrofit2.Call
@@ -24,11 +24,11 @@ class HomeVm : ViewModel() {
     var unsplashL = mutableListOf<UnsplashPhoto>()
     val liveUnsplashL = MutableLiveData<MutableList<UnsplashPhoto>>()
 
-    var todayVerse = JsonObject()   //홈 페이지 성경 일독 : 가져올때마다 랜덤으로 구절이 변함
-    val liveTodayVerse = MutableLiveData<JsonObject>()
+    var todayVerse: HomeVerseDto? = null   //홈 페이지 성경 일독 : 가져올때마다 랜덤으로 구절이 변함
+    val liveTodayVerse = MutableLiveData<HomeVerseDto>()
 
-    var unsplashRandomL = JsonArray()   //홈 페이지 이미지 : api에서 10개식 랜덤으로 가져오기
-    val liveUnsplashRandomL = MutableLiveData<JsonArray>()
+    var unsplashRandomL = mutableListOf<RandomImageDto>()   //홈 페이지 이미지 : api에서 10개식 랜덤으로 가져오기
+    val liveUnsplashRandomL = MutableLiveData<List<RandomImageDto>>()
 
 //    val text: LiveData<String>
 //        get() = mText
@@ -42,23 +42,23 @@ class HomeVm : ViewModel() {
 
 
 
-    fun 성경일독(isExeInVm: Boolean): Call<JsonObject>? {
+    fun 성경일독(isExeInVm: Boolean): Call<HomeVerseDto>? {
         val retrofit = Http.getRetrofitInstance(Http.HOST_IP)
         val httpHome = retrofit.create(Http.HttpHome::class.java) // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
-        val call = httpHome.성경일독(/*MyApp.userInfo.user_no*/)
+        val call = httpHome.성경일독()
         if (isExeInVm) { //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
 //            val resp = suspendCoroutine { cont: Continuation<Unit> ->
-                call.enqueue(object : Callback<JsonObject?> {
-                    override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
+                call.enqueue(object : Callback<HomeVerseDto?> {
+                    override fun onResponse(call: Call<HomeVerseDto?>, response: Response<HomeVerseDto?>) {
                         if (response.isSuccessful) {
                             val res = response.body()!!
-                            todayVerse = res.get("result").asJsonObject
+                            todayVerse = res
                             liveTodayVerse.value = todayVerse
                             Log.e(tagName, "성경일독 onResponse: ${gson.toJson(res)}")
 //                            cont.resumeWith(Result.success(Unit))
                         }
                     }
-                    override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
+                    override fun onFailure(call: Call<HomeVerseDto?>, t: Throwable) {
                         Log.e(tagName, "성경일독 onFailure: " + t.message)
                     }
                 })
@@ -67,23 +67,23 @@ class HomeVm : ViewModel() {
         return call
     }
 
-    fun 랜덤이미지(isExeInVm: Boolean): Call<JsonArray>? {
+    fun 랜덤이미지(isExeInVm: Boolean): Call<List<RandomImageDto>>? {
         val retrofit = Http.getRetrofitInstance(Http.UNSPLASH_API_URL) //api로 이미지 10개식 받아오기
         val httpHome = retrofit.create(Http.HttpHome::class.java) // 통신 구현체 생성(미리 보낼 쿼리스트링 설정해두는거)
         val call = httpHome.랜덤이미지("christian", 10)
         if (isExeInVm) { //true를 받으면 여기서(vm) 실행하고 결과완료된 call을 리턴. false면 완료안된 call을 리턴해서 호출한 fragment or rva에서 비동기 로직 진행.
 //            val resp = suspendCoroutine { cont: Continuation<Unit> ->
-                call.enqueue(object : Callback<JsonArray?> {
-                    override fun onResponse(call: Call<JsonArray?>, response: Response<JsonArray?>) {
+                call.enqueue(object : Callback<List<RandomImageDto>?> {
+                    override fun onResponse(call: Call<List<RandomImageDto>?>, response: Response<List<RandomImageDto>?>) {
                         if (response.isSuccessful) {
                             val res = response.body()!!
-                            unsplashRandomL = res.asJsonArray
+                            unsplashRandomL = res.toMutableList()
                             liveUnsplashRandomL.value = unsplashRandomL
                             Log.e(tagName, "랜덤이미지 onResponse: ${gson.toJson(res)}")
 //                            cont.resumeWith(Result.success(Unit))
                         }
                     }
-                    override fun onFailure(call: Call<JsonArray?>, t: Throwable) {
+                    override fun onFailure(call: Call<List<RandomImageDto>?>, t: Throwable) {
                         Log.e(tagName, "랜덤이미지 onFailure: " + t.message)
                     }
                 })

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteFm.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteFm.kt
@@ -22,7 +22,6 @@ import jm.preversion.biblewith.R
 import jm.preversion.biblewith.bible.BibleVm
 import jm.preversion.biblewith.databinding.MyNoteFmListBinding
 import jm.preversion.biblewith.util.ImageHelper
-import com.google.gson.JsonArray
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteFmUpdate.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteFmUpdate.kt
@@ -65,17 +65,17 @@ class MyNoteFmUpdate : Fragment() {
             val gson = Gson()
             var sendJsonO = JsonObject()
             sendJsonO.addProperty("user_no", MyApp.userInfo.user_no)
-            sendJsonO.addProperty("note_no", bibleVm.noteUpdateO.get("note_no").asInt )
+            sendJsonO.addProperty("note_no", bibleVm.noteUpdateO.note_no )
             sendJsonO.addProperty("note_content", binding.myNoteContentInput.text.toString())
 //            sendJsonO.add("note_verseL", JsonParser.parseString(gson.toJson(rva.newL)).asJsonArray)
             //추가 비동기 실행
-            bibleVm.노트수정(sendJsonO, false).enqueue(object : Callback<JsonObject> {
-                override fun onResponse(call: Call<JsonObject>, response: Response<JsonObject>) {
+            bibleVm.노트수정(sendJsonO, false).enqueue(object : Callback<ResultDto> {
+                override fun onResponse(call: Call<ResultDto>, response: Response<ResultDto>) {
                     if (response.isSuccessful ){
-                        var res : JsonObject? = response.body()
+                        var res : ResultDto? = response.body()
                         Log.e("[MyNoteFmUpdate]", "노트수정 onResponse: $res")
                         //서버로부터 받은 추가된 절이 1개 이상이면 정상추가로 판단하고 이전 페이지로 돌아감.
-                        if(res!!.get("result").asBoolean ){
+                        if(res!!.result ){
                             Toast.makeText(activity,"노트를 수정하였습니다.", Toast.LENGTH_SHORT).show()
                             Navigation.findNavController(view).navigateUp()
                         } else {
@@ -83,7 +83,7 @@ class MyNoteFmUpdate : Fragment() {
                         }
                     }
                 }
-                override fun onFailure(call: Call<JsonObject>, t: Throwable) {
+                override fun onFailure(call: Call<ResultDto>, t: Throwable) {
                     Log.e("[MyNoteFmUpdate]", "노트수정 onFailure: ${t.message}")
                 }
             })
@@ -98,9 +98,9 @@ class MyNoteFmUpdate : Fragment() {
         super.onResume()
         //현재 노트에 추가할 선택된 절이 속한 책,장 정보를 표시
 //        binding.myNoteFmUpdateWhereTv.text = bibleVm.bookL[bibleVm.책장번호[0] - 1].book_name + " " + bibleVm.chapterL[bibleVm.책장번호[1] - 1].chapter + "장"
-        binding.myNoteFmUpdateWhereTv.text = "${bibleVm.bookL[(bibleVm.noteUpdateO.get("note_verseL").asJsonArray.get(0).asJsonObject.get("book").asInt) - 1].book_name} ${bibleVm.noteUpdateO.get("note_verseL").asJsonArray.get(0).asJsonObject.get("chapter").asString}장"
-        binding.myNoteFmUpdateDateTv.text = getTime("ui", bibleVm.noteUpdateO.get("note_date").asString)
-        binding.myNoteContentInput.setText(bibleVm.noteUpdateO.get("note_content").asString)
+        binding.myNoteFmUpdateWhereTv.text = "${bibleVm.bookL[bibleVm.noteUpdateO.note_verseL[0].book - 1].book_name} ${bibleVm.noteUpdateO.note_verseL[0].chapter}장"
+        binding.myNoteFmUpdateDateTv.text = getTime("ui", bibleVm.noteUpdateO.note_date)
+        binding.myNoteContentInput.setText(bibleVm.noteUpdateO.note_content)
     }
 
     override fun onDestroyView() {

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteFmUpdateRva.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteFmUpdateRva.kt
@@ -6,8 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import jm.preversion.biblewith.bible.dto.BibleDto
 import jm.preversion.biblewith.bible.BibleVm
 import jm.preversion.biblewith.databinding.MyNoteFmUpdateVhBinding
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
+import jm.preversion.biblewith.bible.dto.NoteVerseDto
 
 class MyNoteFmUpdateRva(val bibleVm: BibleVm, val myNoteFmUpdate: MyNoteFmUpdate) : RecyclerView.Adapter<MyNoteFmUpdateRva.MyNoteFmUpdateVh>() {
     lateinit var newL : List<BibleDto>
@@ -22,9 +21,24 @@ class MyNoteFmUpdateRva(val bibleVm: BibleVm, val myNoteFmUpdate: MyNoteFmUpdate
 
     override fun getItemCount(): Int {
 //        newL = bibleVm.verseL.filter{ it.highlight_selected }
-        var gson = Gson()
-        var verseL = bibleVm.noteUpdateO.get("note_verseL").asJsonArray
-        var nL :List<BibleDto> = gson.fromJson<List<BibleDto>>(verseL, object : TypeToken<ArrayList<BibleDto?>?>() {}.type)
+        var verseL = bibleVm.noteUpdateO.getNote_verseL()
+        var nL :List<BibleDto> = verseL.map {
+            BibleDto(
+                it.bible_no ?: 0,
+                "",
+                it.book,
+                bibleVm.bookL[it.book - 1].book_name,
+                it.chapter,
+                it.verse,
+                it.content,
+                0,
+                "",
+                0,
+                0,
+                false,
+                false
+            )
+        }
         newL = nL
 //        newL = bibleVm.verseL.filter{ it.highlight_selected }
         return newL.size

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteRva.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteRva.kt
@@ -13,8 +13,8 @@ import jm.preversion.biblewith.MyApp
 import jm.preversion.biblewith.R
 import jm.preversion.biblewith.bible.BibleVm
 import jm.preversion.biblewith.databinding.MyNoteFmVhBinding
-import com.google.gson.JsonArray
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.bible.dto.NoteDto
+import jm.preversion.biblewith.bible.dto.NoteVerseDto
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -29,11 +29,11 @@ class MyNoteRva(val bibleVm: BibleVm, val myNoteFm: MyNoteFm) : RecyclerView.Ada
     }
 
     override fun onBindViewHolder(holder: MyNoteFmVh, position: Int) {
-        holder.bind(bibleVm.noteL[position] as JsonObject)
+        holder.bind(bibleVm.noteL[position])
     }
 
     override fun getItemCount(): Int {
-        return bibleVm.noteL.size()
+        return bibleVm.noteL.size
     }
 
 
@@ -49,16 +49,16 @@ class MyNoteRva(val bibleVm: BibleVm, val myNoteFm: MyNoteFm) : RecyclerView.Ada
         }
 
         //mItem -- 노트목록가져오기() :getNoteList 메소드로부터
-        fun bind(mItem: JsonObject) {
+        fun bind(mItem: NoteDto) {
 //            this.mItem = mItem;
-            binding.myNoteFmVhWhereTv.text = "${bibleVm.bookL[(mItem.get("note_verseL").asJsonArray.get(0).asJsonObject.get("book").asInt) - 1].book_name} ${mItem.get("note_verseL").asJsonArray.get(0).asJsonObject.get("chapter").asString}장"
-            binding.myNoteFmVhDateTv.text = MyApp.getTime("ui", mItem.get("note_date").asString)
-            binding.myNoteFmVhContentTv.text = mItem.get("note_content").asString
+            binding.myNoteFmVhWhereTv.text = "${bibleVm.bookL[mItem.getNote_verseL().get(0).getBook() - 1].book_name} ${mItem.getNote_verseL().get(0).getChapter()}장"
+            binding.myNoteFmVhDateTv.text = MyApp.getTime("ui", mItem.getNote_date())
+            binding.myNoteFmVhContentTv.text = mItem.getNote_content()
 
 //            Log.e("오류태그outter", "$mItem")
             rv = binding.myNoteFmVhVerseList
             rv!!.layoutManager = LinearLayoutManager(binding.root.context)
-            binding.myNoteFmVhVerseList.adapter = MyNoteRvaInner(bibleVm, myNoteFm, this, mItem.get("note_verseL").asJsonArray)
+            binding.myNoteFmVhVerseList.adapter = MyNoteRvaInner(bibleVm, myNoteFm, this, mItem.getNote_verseL())
             rva = rv?.adapter as MyNoteRvaInner
 //            binding.dto = mItem
 
@@ -85,14 +85,14 @@ class MyNoteRva(val bibleVm: BibleVm, val myNoteFm: MyNoteFm) : RecyclerView.Ada
                             alertdialog.setPositiveButton("확인") { dialog, which ->
                                 // Toast toast = Toast.makeText(getActivity(), "확인 버튼 눌림", Toast.LENGTH_SHORT ).show;
                                 //비동기 정보 가져옴
-                                bibleVm.노트삭제(mItem.get("note_no").asInt, false).enqueue(object : Callback<JsonObject?> {
-                                    override fun onResponse(call: Call<JsonObject?>, response: Response<JsonObject?>) {
+                                bibleVm.노트삭제(mItem.getNote_no(), false).enqueue(object : Callback<ResultDto?> {
+                                    override fun onResponse(call: Call<ResultDto?>, response: Response<ResultDto?>) {
                                         if (response.isSuccessful) {
                                             val res = response.body()
-                                            if(res!!.get("result").asBoolean){
+                                            if(res!!.result){
                                                 Toast.makeText(myNoteFm.context, "노트를 삭제하였습니다",Toast.LENGTH_SHORT).show()
-                                                bibleVm.노트목록가져오기(false).enqueue(object : Callback<JsonArray?> {
-                                                    override fun onResponse(call: Call<JsonArray?>, response: Response<JsonArray?>) {
+                                                bibleVm.노트목록가져오기(false).enqueue(object : Callback<List<NoteDto>?> {
+                                                    override fun onResponse(call: Call<List<NoteDto>?>, response: Response<List<NoteDto>?>) {
                                                         if (response.isSuccessful) {
                                                             val res = response.body()
                                                             Log.e("[MyNoteFm]", "노트목록가져오기 onResponse: $res")
@@ -101,14 +101,14 @@ class MyNoteRva(val bibleVm: BibleVm, val myNoteFm: MyNoteFm) : RecyclerView.Ada
                                                             notifyDataSetChanged()
                                                         }
                                                     }
-                                                    override fun onFailure(call: Call<JsonArray?>, t: Throwable) {
+                                                    override fun onFailure(call: Call<List<NoteDto>?>, t: Throwable) {
                                                         Log.e("[MyNoteFm]", "노트목록가져오기 onFailure: " + t.message)
                                                     }
                                                 })
                                             }
                                         }
                                     }
-                                    override fun onFailure(call: Call<JsonObject?>, t: Throwable) {
+                                    override fun onFailure(call: Call<ResultDto?>, t: Throwable) {
                                         Log.e("[BibleVm]", "노트삭제 onFailure: " + t.message)
                                     }
                                 })

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteRvaInner.kt
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/moreinfo/MyNoteRvaInner.kt
@@ -6,12 +6,10 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import jm.preversion.biblewith.bible.BibleVm
 import jm.preversion.biblewith.databinding.MyNoteFmVhInVhBinding
-import com.google.gson.JsonArray
-import com.google.gson.JsonElement
-import com.google.gson.JsonObject
+import jm.preversion.biblewith.bible.dto.NoteVerseDto
 
 class MyNoteRvaInner(
-    val bibleVm: BibleVm, val myNoteFm: MyNoteFm, val myNoteFmVh: MyNoteRva.MyNoteFmVh, val note_verseL: JsonArray
+    val bibleVm: BibleVm, val myNoteFm: MyNoteFm, val myNoteFmVh: MyNoteRva.MyNoteFmVh, val note_verseL: List<NoteVerseDto>
 ) : RecyclerView.Adapter<MyNoteRvaInner.MyNoteFmVhInVh>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyNoteFmVhInVh {
@@ -19,11 +17,11 @@ class MyNoteRvaInner(
     }
 
     override fun onBindViewHolder(holder: MyNoteFmVhInVh, position: Int) {
-        holder.bind(note_verseL[position] as JsonObject)
+        holder.bind(note_verseL[position])
     }
 
     override fun getItemCount(): Int {
-        return note_verseL.size()
+        return note_verseL.size
     }
 
 
@@ -33,12 +31,12 @@ class MyNoteRvaInner(
         init {
         }
 
-        fun bind(mItem: JsonObject) {
+        fun bind(mItem: NoteVerseDto) {
 //            Log.e("오류태그", "$mItem")
 //            this.mItem = mItem;
 //            binding.dto = mItem
-            binding.myNoteFmVhInVhWhereTv.text = "${bibleVm.bookL[(mItem.get("book").asInt) - 1].book_name} ${mItem.get("chapter").asString}장 ${mItem.get("verse").asString}절"
-            binding.myNoteFmVhInVhVerseTv.text = mItem.get("content").asString
+            binding.myNoteFmVhInVhWhereTv.text = "${bibleVm.bookL[mItem.book - 1].book_name} ${mItem.chapter}장 ${mItem.verse}절"
+            binding.myNoteFmVhInVhVerseTv.text = mItem.content
 
         }
 

--- a/androidclient/app/src/main/java/jm/preversion/biblewith/util/Http.java
+++ b/androidclient/app/src/main/java/jm/preversion/biblewith/util/Http.java
@@ -1,6 +1,10 @@
 package jm.preversion.biblewith.util;
 
 import jm.preversion.biblewith.bible.dto.BibleDto;
+import jm.preversion.biblewith.bible.dto.NoteDto;
+import jm.preversion.biblewith.bible.dto.ResultDto;
+import jm.preversion.biblewith.bible.dto.HomeVerseDto;
+import jm.preversion.biblewith.bible.dto.RandomImageDto;
 import jm.preversion.biblewith.login.LoginDto;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -126,7 +130,7 @@ public class Http {
 
         //성경일독
         @GET("bible/getTodayLang")
-        Call<JsonObject> 성경일독();
+        Call<HomeVerseDto> 성경일독();
 
         //Unsplash Api 랜덤 이미지 10장
         @Headers({
@@ -134,7 +138,7 @@ public class Http {
             "content-type: application/json"
         })
         @GET("/photos/random")
-        Call<JsonArray> 랜덤이미지(@Query("query") String query, @Query("count") int count);
+        Call<List<RandomImageDto>> 랜덤이미지(@Query("query") String query, @Query("count") int count);
     }
 
 
@@ -177,23 +181,23 @@ public class Http {
         //유저 노트 목록 가져오기
 //        @Headers("content-type: application/json")
         @GET("bible/getNoteList")
-        Call<JsonArray> getNoteList(@Query("user_no") int user_no);
+        Call<List<NoteDto>> getNoteList(@Query("user_no") int user_no);
 
         //유저 노트 추가
         @Headers("content-type: application/json")
         @POST("bible/getNoteAdd")
-        Call<JsonObject> getNoteAdd(@Body JsonObject noteinfo);
+        Call<ResultDto> getNoteAdd(@Body JsonObject noteinfo);
 
         //유저 노트 수정
         @Headers("content-type: application/json")
         @POST("bible/getNoteUpdate")
-        Call<JsonObject> getNoteUpdate(@Body JsonObject noteinfo);
+        Call<ResultDto> getNoteUpdate(@Body JsonObject noteinfo);
 
 
         //유저 노트 삭제
         @Headers("content-type: application/json")
         @POST("bible/deleteNote")
-        Call<JsonObject> deleteNote(@Query("note_no") int note_no);
+        Call<ResultDto> deleteNote(@Query("note_no") int note_no);
     }
 
 


### PR DESCRIPTION
## Summary
- introduce several DTO data classes for notes, home verse and images
- refactor Http API interfaces to return DTOs
- adjust Home view models and fragments to use new DTOs
- refactor BibleVm note methods and note related UIs

## Testing
- `gradle test` *(fails: not applicable)*

------
https://chatgpt.com/codex/tasks/task_e_68431e7ec830832b819a3a4e3309a8ab